### PR TITLE
RAM inferring fix - reduced cost

### DIFF
--- a/ql-qlf-plugin/qlf_k6n10f/libmap_brams.txt
+++ b/ql-qlf-plugin/qlf_k6n10f/libmap_brams.txt
@@ -9,7 +9,7 @@ ram block $__QLF_TDP36K {
 		abits 14;
 		widths 1 2 4 9 18 per_port;
 	}
-	cost 257;
+	cost 65;
 	port srsw "A" "B" {
 		width tied;
 		clock posedge;


### PR DESCRIPTION
ram cost reduced to 65 from 257 in libmap_brams.txt