### PR TITLE
Add pass to read/write files with memory initialization data

### DIFF
--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -24,6 +24,7 @@ SOURCES = synth_quicklogic.cc \
           ql-edif.cc \
           ql-dsp-simd.cc \
           ql-dsp-macc.cc \
+          ql-bram-initfile.cc \
           ql-bram-split.cc \
           ql-bram-merge.cc \
           ql-dsp-io-regs.cc \

--- a/ql-qlf-plugin/ql-bram-initfile.cc
+++ b/ql-qlf-plugin/ql-bram-initfile.cc
@@ -1,0 +1,195 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2023  Martin Povišer <povik@cutebit.org>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/register.h"
+
+USING_YOSYS_NAMESPACE
+PRIVATE_NAMESPACE_BEGIN
+
+#define QL_HEXFILE_BITSTRIDE 36
+
+std::string hexdump(std::vector<State>::iterator start, std::vector<State>::iterator end)
+{
+    std::string ret;
+    ret.reserve(9);
+    for (auto p = start; p != end;) {
+        auto ne = p + 4;
+        int nibble = 0;
+        for (int i = 0; p != end && p != ne; p++, i++)
+            if (*p == State::S1)
+                nibble |= 1 << i;
+        ret += (nibble < 10 ? '0' + nibble : 'A' - 10 + nibble);
+    }
+    return ret;
+}
+
+void write_hex(const char *name, std::ostream &s, Const data)
+{
+    log_assert(data.size() % QL_HEXFILE_BITSTRIDE == 0);
+    for (auto p = data.bits.begin(); p != data.bits.end(); p += QL_HEXFILE_BITSTRIDE)
+        s << hexdump(p, p + 36) << "\n";
+
+    if (s.fail())
+        log_error("Failed to write to %s\n", name);
+}
+
+void read_hex(const char *name, std::istream &s, Const &data)
+{
+    log_assert(data.size() % QL_HEXFILE_BITSTRIDE == 0);
+    char line[16];
+    int lineno = 0;
+    int p = 0;
+    while (!s.getline(line, sizeof(line)).fail() &&
+            lineno < data.size() / QL_HEXFILE_BITSTRIDE) {
+        lineno++;
+        int i;
+        for (i = 0; i < 9; i++) {
+            int nibble;
+            switch (line[i]) {
+            case '0' ... '9':
+                nibble = line[i] - '0';
+                break;
+            case 'A' ... 'F':
+                nibble = line[i] - 'A' + 10;
+                break;
+            default:
+                goto bad_data;
+            }
+
+            for (int k = 0; k < 4; k++)
+                data[(lineno - 1) * 36 + i * 4 + k] = nibble & 1 << k ? State::S1 : State::S0;
+        }
+
+        if (!line[i])
+            continue;
+
+    bad_data:
+        log_error("Bad data on line %d of %s: %s", lineno, name, line);
+    }
+
+    if (s.eof())
+        return;
+
+    if (s.fail())
+        log_error("Failed to read %s\n", name);
+
+    lineno++;
+    log_error("Overrun data on line %d in %s\n", lineno, name);
+}
+
+struct QlBramInitfilePass : Pass {
+    QlBramInitfilePass() : Pass("ql_bram_initfile", "read or write RAM init files in QuickLogic flows") {}
+
+    void help() override
+    {
+        //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+        log("\n");
+        log("    ql_bram_initfile {-read|-write} [-path <dir-path>] [selection]\n");
+        log("\n");
+        log("This pass reads/writes initialization data on QuickLogic BRAM primitives from/to\n");
+        log("an external file. The filename is stored in the RAM_INIT_FILE parameter, the\n");
+        log("value of which will be generated if not set.\n");
+        log("\n");
+        log("    -read -write\n");
+        log("        select a read or write mode\n");
+        log("\n");
+        log("    -path <dir-path>\n");
+        log("        set the base directory path relative to which the RAM_INIT_FILE filenames\n");
+        log("        are interpreted\n");
+        log("\n");
+    }
+
+    void execute(std::vector<std::string> args, RTLIL::Design *design) override
+    {
+        log_header(design, "Executing QL_BRAM_INITFILE pass. (read or write RAM init files in QuickLogic flows)\n");
+        std::string dir_path;
+        bool read = false, write = false;
+
+        size_t argidx;
+        for (argidx = 1; argidx < args.size(); argidx++) {
+            if (args[argidx] == "-read")
+                read = true;
+            else if (args[argidx] == "-write")
+                write = true;
+            else if (args[argidx] == "-path" && argidx + 1 < args.size())
+                dir_path = args[++argidx];
+            else
+                break;
+        }
+        extra_args(args, argidx, design);
+
+        if ((!read && !write) || (read && write))
+            log_error("One of read or write modes needs to be selected.\n");
+
+        pool<std::string> used_filenames;
+
+        for (auto module : design->selected_modules()) {
+            for (auto cell : module->selected_cells()) {
+                if (!cell->type.in(ID(TDP36K)))
+                    continue;
+
+                if (write && !cell->hasParam(ID(RAM_INIT_FILE))) {
+                    std::string fn = RTLIL::unescape_id(cell->name.str());
+                    std::replace(fn.begin(), fn.end(), '\\', '_');
+                    std::replace(fn.begin(), fn.end(), ':', '_');
+
+                    while (used_filenames.count(fn))
+                        fn += "_";
+
+                    log("Setting parameter %s.RAM_DATA_FILE = %s\n",
+                        log_id(cell->name), fn.c_str());
+                    cell->setParam(ID(RAM_INIT_FILE), fn);
+                }
+
+                if (!cell->hasParam(ID(RAM_INIT_FILE))) {
+                    log_warning("%s cell %s lacks RAM_DATA_FILE parameter, cell skipped.\n",
+                                log_id(cell->type), log_id(cell));
+                    continue;
+                }
+                // TODO: secure joining of the path parts
+                std::string param_path = cell->getParam(ID(RAM_INIT_FILE)).decode_string();
+                std::string path = dir_path.empty() ? param_path : (dir_path + "/" + param_path);
+
+                int datalen = 36 * 1024;
+                if (read) {
+                    std::ifstream f;
+                    f.open(path);
+                    if (f.fail())
+                        log_error("Failed to open file: %s\n", path.c_str());
+                    Const data(State::Sx, datalen);
+                    read_hex(path.c_str(), f, data);
+                    cell->setParam(ID(RAM_INIT), data);
+                }
+
+                if (write) {
+                    std::ofstream f;
+                    f.open(path);
+                    if (f.fail())
+                        log_error("Failed to open file: %s\n", path.c_str());
+                    Const data = cell->getParam(ID(RAM_INIT));
+                    if (data.size() != datalen)
+                        log_error("Invalid length of %s.RAM_INIT: %d\n", log_id(cell->name), data.size());
+                    write_hex(path.c_str(), f, data);
+                }
+            }
+        }
+    }
+} QlBramInitfilePass;
+
+PRIVATE_NAMESPACE_END

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -69,6 +69,10 @@ struct SynthQuickLogicPass : public ScriptPass {
         log("        write the design to the specified verilog file. Writing of an output\n");
         log("        file is omitted if this parameter is not specified.\n");
         log("\n");
+        log("    -meminit <dir-path>\n");
+        log("        write block memory initialization data into files created below\n");
+        log("        the specified path (qlf_k6n10f only).\n");
+        log("\n");
         log("    -no_dsp\n");
         log("        By default use DSP blocks in output netlist.\n");
         log("        do not use DSP blocks to implement multipliers and associated logic\n");
@@ -107,7 +111,7 @@ struct SynthQuickLogicPass : public ScriptPass {
         log("\n");
     }
 
-    string top_opt, edif_file, blif_file, family, currmodule, verilog_file, use_dsp_cfg_params, lib_path;
+    string top_opt, edif_file, blif_file, meminit_dir, family, currmodule, verilog_file, use_dsp_cfg_params, lib_path;
     bool nodsp;
     bool inferAdder;
     bool inferBram;
@@ -124,6 +128,7 @@ struct SynthQuickLogicPass : public ScriptPass {
         edif_file = "";
         blif_file = "";
         verilog_file = "";
+        meminit_dir = "";
         currmodule = "";
         family = "qlf_k4n8";
         inferAdder = true;
@@ -176,6 +181,10 @@ struct SynthQuickLogicPass : public ScriptPass {
             }
             if (args[argidx] == "-verilog" && argidx + 1 < args.size()) {
                 verilog_file = args[++argidx];
+                continue;
+            }
+            if (args[argidx] == "-meminit" && argidx + 1 < args.size()) {
+                meminit_dir = args[++argidx];
                 continue;
             }
             if (args[argidx] == "-no_dsp") {
@@ -653,6 +662,10 @@ struct SynthQuickLogicPass : public ScriptPass {
             }
             run("check");
             run("blackbox =A:whitebox");
+        }
+
+        if (check_label("meminit", "(if -meminit, for qlf_k6n10f)") && (help_mode || (family == "qlf_k6n10f" && !meminit_dir.empty()))) {
+            run("ql_bram_initfile -write -path " + (help_mode ? "<dir-path>" : meminit_dir));
         }
 
         if (check_label("blif", "(if -blif)")) {


### PR DESCRIPTION
Per the inquiry in issue #1 I put together a pass to extract memory initialization data into separate files:

```
    ql_bram_initfile {-read|-write} [-path <dir-path>] [selection]

This pass reads/writes initialization data on QuickLogic BRAM primitives from/to
an external file. The filename is stored in the RAM_INIT_FILE parameter, the
value of which will be generated if not set.

    -read -write
        select a read or write mode

    -path <dir-path>
        set the base directory path relative to which the RAM_INIT_FILE filenames
        are interpreted
```

I hooked it up as an option in `synth_quicklogic`:

```
    -meminit <dir-path>
        write block memory initialization data into files created below
        the specified path (qlf_k6n10f only).
```

Feel free to suggest better naming.

Some points to discuss:

 * The format of the data: Currently it's 36 bits of hex-encoded data per line.

 * Handling of undef bits: There's no handling of it as of now, so when the data is being written all x-bits are replaced with zero.

 * Retaining of the `RAM_INIT` parameter: The data in the `RAM_INIT` parameter is kept on the cells even after being written down into the extra files. One thing to consider is resetting it so that it doesn't take up space in the output BLIF/EDIF/Verilog files. I don't know if resetting it to a fully-sized vector of undef bits will lead to a compressed representation in any of the output formats. Another option is to reset it to a zero-sized value.