### PR TITLE
Support LUT6 as a blackbox

### DIFF
--- a/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
+++ b/ql-qlf-plugin/qlf_k6n10f/cells_sim.v
@@ -146,6 +146,47 @@ module adder_carry(
 
 endmodule
 
+(* abc9_box, lib_whitebox *)
+(* blackbox *)
+(* keep *)
+module lut6(
+    input wire [0:5] in,
+    output wire out
+);
+    parameter [0:63] LUT = 0;
+    // Effective LUT input
+    wire [0:5] li = in;
+
+    // Output function
+    wire [0:31] s1 = li[0] ?
+    {LUT[0] , LUT[2] , LUT[4] , LUT[6] , LUT[8] , LUT[10], LUT[12], LUT[14], 
+     LUT[16], LUT[18], LUT[20], LUT[22], LUT[24], LUT[26], LUT[28], LUT[30],
+     LUT[32], LUT[34], LUT[36], LUT[38], LUT[40], LUT[42], LUT[44], LUT[46],
+     LUT[48], LUT[50], LUT[52], LUT[54], LUT[56], LUT[58], LUT[60], LUT[62]}:
+    {LUT[1] , LUT[3] , LUT[5] , LUT[7] , LUT[9] , LUT[11], LUT[13], LUT[15], 
+     LUT[17], LUT[19], LUT[21], LUT[23], LUT[25], LUT[27], LUT[29], LUT[31],
+     LUT[33], LUT[35], LUT[37], LUT[39], LUT[41], LUT[43], LUT[45], LUT[47],
+     LUT[49], LUT[51], LUT[53], LUT[55], LUT[57], LUT[59], LUT[61], LUT[63]};
+
+    wire [0:15] s2 = li[1] ?
+    {s1[0] , s1[2] , s1[4] , s1[6] , s1[8] , s1[10], s1[12], s1[14],
+     s1[16], s1[18], s1[20], s1[22], s1[24], s1[26], s1[28], s1[30]}:
+    {s1[1] , s1[3] , s1[5] , s1[7] , s1[9] , s1[11], s1[13], s1[15],
+     s1[17], s1[19], s1[21], s1[23], s1[25], s1[27], s1[29], s1[31]};
+
+    wire [0:7] s3 = li[2] ?
+    {s2[0], s2[2], s2[4], s2[6], s2[8], s2[10], s2[12], s2[14]}:
+    {s2[1], s2[3], s2[5], s2[7], s2[9], s2[11], s2[13], s2[15]};
+
+    wire [0:3] s4 = li[3] ? {s3[0], s3[2], s3[4], s3[6]}:
+                            {s3[1], s3[3], s3[5], s3[7]};
+
+    wire [0:1] s5 = li[4] ? {s4[0], s4[2]} : {s4[1], s4[3]};
+
+    assign out = li[5] ? s5[0] : s5[1];
+
+endmodule
+
 (* abc9_flop, lib_whitebox *)
 module dff(
     output reg Q,


### PR DESCRIPTION
In this PR, I have added lut6 module definitions to cells_sim.v to be able to pass the synthesis stage while designers directly use LUT6 as a standalone module in their Verilog design. 


Please review the following code changes and let me know if you have any suggestions.
@tpagarani 