### PR TITLE
Add TabbyCAD Support For MacOS

### DIFF
--- a/ql-qlf-plugin/ql-bram-split.cc
+++ b/ql-qlf-plugin/ql-bram-split.cc
@@ -51,7 +51,14 @@ struct QlBramSplitPass : public Pass {
         BramConfig(const BramConfig &ref) = default;
         BramConfig(BramConfig &&ref) = default;
 
-        unsigned int hash() const { return connections.hash(); }
+        #if defined YS_HASHING_VERSION && YS_HASHING_VERSION == 1
+                Hasher hash_into(Hasher h) const {
+                h.eat(connections);
+                return h;
+                }
+        #else
+            #error "This version of Yosys uses an unsupported hashing interface"
+        #endif
 
         bool operator==(const BramConfig &ref) const { return connections == ref.connections; }
     };

--- a/ql-qlf-plugin/ql-dsp-simd.cc
+++ b/ql-qlf-plugin/ql-dsp-simd.cc
@@ -67,7 +67,14 @@ struct QlDspSimdPass : public Pass {
         DspConfig(const DspConfig &ref) = default;
         DspConfig(DspConfig &&ref) = default;
 
-        unsigned int hash() const { return connections.hash(); }
+        #if defined YS_HASHING_VERSION && YS_HASHING_VERSION == 1
+                Hasher hash_into(Hasher h) const {
+                h.eat(connections);
+                return h;
+                }
+        #else
+            #error "This version of Yosys uses an unsupported hashing interface"
+        #endif
 
         bool operator==(const DspConfig &ref) const { return connections == ref.connections && use_cfg_params == ref.use_cfg_params; }
     };

--- a/sdc-plugin/sdc.cc
+++ b/sdc-plugin/sdc.cc
@@ -35,6 +35,9 @@
 #include "set_clock_groups.h"
 #include "set_false_path.h"
 #include "set_max_delay.h"
+#ifdef YOSYS_ENABLE_TCL
+#  include <tcl.h>
+#endif
 
 USING_YOSYS_NAMESPACE
 


### PR DESCRIPTION
- Update yosys-plugins to work with Yosys v0.55 as TabbyCAD based on v0.55 has MacOS build support now