### PR TITLE
Adding a graceful exit for using unsupported synthesis tools with dspv2

### DIFF
--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -398,6 +398,9 @@ struct SynthQuickLogicPass : public ScriptPass {
             // Read simulation library
             readVelArgs = family_path + "/cells_sim.v";
             if (family == "qlf_k6n10f") {
+                if(!synplify && dspv2) {
+                    log_cmd_error("DSPV2 is only supported with Synplify.\nPlease use Synplify as your synthesis tool.\n");
+                }
 				if (dspv2) {
 					readVelArgs += family_path + "/dspv2_sim.v";
 				}


### PR DESCRIPTION
This PR adds a graceful exit if Synplify is not used as the synthesis tool when using DSPV2.