### PR TITLE
DSPV2 Synthesis Pass Revision

### DIFF
--- a/ql-qlf-plugin/ql_dspv2_types.cc
+++ b/ql-qlf-plugin/ql_dspv2_types.cc
@@ -58,7 +58,7 @@ struct QlDSPV2TypesPass : public Pass {
 
 		RTLIL::SigSpec sig = cell->getPort(port_name);
 
-		log("Cell %s %s = %s\n",
+		log_debug("Cell %s %s = %s\n",
 			log_id(cell), log_id(port_name), log_signal(sig));
 
 		if (!sig.is_fully_const())
@@ -68,7 +68,7 @@ struct QlDSPV2TypesPass : public Pass {
 		RTLIL::Const c = sig.as_const();
 		int value = c.as_int();
 
-		log("%s value: %d\n", log_id(port_name), value);
+		log_debug("%s value: %d\n", log_id(port_name), value);
 
 		return value;
 	}
@@ -131,7 +131,7 @@ struct QlDSPV2TypesPass : public Pass {
 			dff->setPort(IdString("\\R"), rst);
 			dff->setPort(IdString("\\E"), SigSpec());
 
-			log("Added bit %d dffre BEFORE: D=%s, Q=%s\n", i, log_signal(bit_in), log_signal(bit_out));
+			log_debug("Added bit %d dffre BEFORE: D=%s, Q=%s\n", i, log_signal(bit_in), log_signal(bit_out));
 		}
 	}
 
@@ -174,7 +174,7 @@ struct QlDSPV2TypesPass : public Pass {
 			dff->setPort(IdString("\\R"), rst);
 			dff->setPort(IdString("\\E"), SigSpec());
 
-			log("Added bit %d dffre AFTER: D=%s, Q=%s\n", i, log_signal(bit_in), log_signal(bit_out));
+			log_debug("Added bit %d dffre AFTER: D=%s, Q=%s\n", i, log_signal(bit_in), log_signal(bit_out));
 		}
 	}
 
@@ -222,7 +222,7 @@ struct QlDSPV2TypesPass : public Pass {
 		}
 
 		for (auto &p : ports_to_remove) {
-			log("Removing port %s from cell %s\n",
+			log_debug("Removing port %s from cell %s\n",
 				log_id(p), log_id(cell));
 			cell->unsetPort(p);
 		}
@@ -245,81 +245,81 @@ struct QlDSPV2TypesPass : public Pass {
                 
 
                 int COEFF_0    = mode_bits.extract(0, 31).as_int();
-				log("COEFF_0: %d.\n", COEFF_0);
+				log_debug("COEFF_0: %d.\n", COEFF_0);
                 int ACC_FIR    = mode_bits.extract(32, 6).as_int();
-				log("ACC_FIR: %d.\n", ACC_FIR);
+				log_debug("ACC_FIR: %d.\n", ACC_FIR);
                 int ROUND      = mode_bits.extract(38, 3).as_int();
-				log("ROUND: %d.\n", ROUND);
+				log_debug("ROUND: %d.\n", ROUND);
                 int ZC_SHIFT   = mode_bits.extract(41, 5).as_int();
-				log("ZC_SHIFT: %d.\n", ZC_SHIFT);
+				log_debug("ZC_SHIFT: %d.\n", ZC_SHIFT);
                 int ZREG_SHIFT = mode_bits.extract(46, 5).as_int();
-				log("ZREG_SHIFT: %d.\n", ZREG_SHIFT);
+				log_debug("ZREG_SHIFT: %d.\n", ZREG_SHIFT);
                 int SHIFT_REG  = mode_bits.extract(51, 6).as_int();
-				log("SHIFT_REG: %d.\n", SHIFT_REG);
+				log_debug("SHIFT_REG: %d.\n", SHIFT_REG);
                 
                 bool SATURATE  = mode_bits.extract(57).as_bool();
 				if (SATURATE)
-					log("STARUATE Enabled.\n");
+					log_debug("STARUATE Enabled.\n");
                 bool SUBTRACT  = mode_bits.extract(58).as_bool();
 				if (SUBTRACT)
-					log("SUBTRACT Enabled.\n");
+					log_debug("SUBTRACT Enabled.\n");
                 bool PRE_ADD   = mode_bits.extract(59).as_bool();
                 if (PRE_ADD)
-					log("PRE_ADD Enabled.\n");
+					log_debug("PRE_ADD Enabled.\n");
                 bool A_SEL     = mode_bits.extract(60).as_bool();
 				if (A_SEL)
-					log("A_SEL Enabled.\n");
+					log_debug("A_SEL Enabled.\n");
                 bool A_REG     = mode_bits.extract(61).as_bool();
 				if (A_REG)
-					log("A_REG Enabled.\n");
+					log_debug("A_REG Enabled.\n");
                 bool A1_REG    = mode_bits.extract(62).as_bool();
 				if (A1_REG)
-					log("A1_REG Enabled.\n");
+					log_debug("A1_REG Enabled.\n");
                 bool A2_REG    = mode_bits.extract(63).as_bool();
 				if (A2_REG)
-					log("A2_REG Enabled.\n");
+					log_debug("A2_REG Enabled.\n");
 
                 bool B_SEL     = mode_bits.extract(64).as_bool();
 				if (B_SEL)
-					log("B_SEL Enabled.\n");
+					log_debug("B_SEL Enabled.\n");
                 bool B_REG     = mode_bits.extract(65).as_bool();
 				if (B_REG)
-					log("B_REG Enabled.\n");
+					log_debug("B_REG Enabled.\n");
                 bool B1_REG    = mode_bits.extract(66).as_bool();
 				if (B1_REG)
-					log("B1_REG Enabled.\n");
+					log_debug("B1_REG Enabled.\n");
                 bool B2_REG    = mode_bits.extract(67).as_bool();	
 				if (B2_REG)
-					log("B2_REG Enabled.\n");
+					log_debug("B2_REG Enabled.\n");
 
                 bool C_REG     = mode_bits.extract(68).as_bool();
 				if (C_REG)
-					log("C_REG Enabled.\n");
+					log_debug("C_REG Enabled.\n");
                 bool BC_REG    = mode_bits.extract(69).as_bool();
 				if (BC_REG)
-					log("BC_REG Enabled.\n");
+					log_debug("BC_REG Enabled.\n");
                 bool M_REG     = mode_bits.extract(70).as_bool();
 				if (M_REG)
-					log("M_REG Enabled.\n");
+					log_debug("M_REG Enabled.\n");
                 bool ZCIN_SEL  = mode_bits.extract(71).as_bool();
 				if (ZCIN_SEL)
-					log("ZCIN_SEL Enabled.\n");
+					log_debug("ZCIN_SEL Enabled.\n");
                 bool ACOUT_SEL = mode_bits.extract(72).as_bool();
 				if (ACOUT_SEL)
-					log("ACOUT_SEL Enabled.\n");
+					log_debug("ACOUT_SEL Enabled.\n");
                 bool BCOUT_SEL = mode_bits.extract(73).as_bool();
 				if (BCOUT_SEL)
-					log("BCOUT_SEL Enabled.\n");
+					log_debug("BCOUT_SEL Enabled.\n");
                 bool FRAC_MODE = mode_bits.extract(79).as_bool();
 				if (FRAC_MODE)
-					log("FRAC_MODE Enabled.\n");
+					log_debug("FRAC_MODE Enabled.\n");
 
 				int FEEDBACK = get_const_port_value(cell, ID(feedback));
-				log("FEEDBACK: %d.\n", FEEDBACK);
+				log_debug("FEEDBACK: %d.\n", FEEDBACK);
 				int OUTPUT_SELECT = get_const_port_value(cell, ID(output_select));
-				log("OUTPUT_SELECT: %d.\n", OUTPUT_SELECT);
+				log_debug("OUTPUT_SELECT: %d.\n", OUTPUT_SELECT);
 				int LOAD_ACC = get_const_port_value(cell, ID(load_acc));
-				log("LOAD_ACC: %d.\n", LOAD_ACC);
+				log_debug("LOAD_ACC: %d.\n", LOAD_ACC);
 
 				replace_output_port_and_drop(
 						module,
@@ -390,7 +390,7 @@ struct QlDSPV2TypesPass : public Pass {
 														 SUBTRACT);
 				
 
-				log("Control Word: %d\n", control_word);
+				log_debug("Control Word: %d\n", control_word);
 				std::string type = "QL_DSPV2";
 				switch (control_word){
 					case 0b000000000: //MULT

--- a/ql-qlf-plugin/ql_dspv2_types.cc
+++ b/ql-qlf-plugin/ql_dspv2_types.cc
@@ -179,6 +179,30 @@ struct QlDSPV2TypesPass : public Pass {
 	}
 
 
+	void replace_output_port_and_drop(
+		RTLIL::Module *module,
+		RTLIL::Cell *cell,
+		RTLIL::IdString keep_port,   // ID("\\z")
+		RTLIL::IdString drop_port    // ID("\\z_cout")
+	) {
+		// Safety checks
+		if (!cell->hasPort(keep_port) || !cell->hasPort(drop_port))
+			log_error("Cell %s does not have required ports %s / %s\n",
+					log_id(cell), log_id(keep_port), log_id(drop_port));
+
+		SigMap sigmap(module);
+
+		// Capture signals BEFORE modifying the cell
+		RTLIL::SigSpec keep_sig = sigmap(cell->getPort(keep_port));
+		RTLIL::SigSpec drop_sig = sigmap(cell->getPort(drop_port));
+
+		// 1. Remove the unwanted port
+		cell->unsetPort(drop_port);
+
+		// 2. Reconnect: old drop wire now driven by keep signal
+		module->connect(drop_sig, keep_sig);  // drop = keep
+	}
+
 	void transform_cell_with_ports(
 		RTLIL::Cell *cell,
 		RTLIL::IdString new_type,
@@ -221,60 +245,136 @@ struct QlDSPV2TypesPass : public Pass {
                 
 
                 int COEFF_0    = mode_bits.extract(0, 31).as_int();
+				log("COEFF_0: %d.\n", COEFF_0);
                 int ACC_FIR    = mode_bits.extract(32, 6).as_int();
+				log("ACC_FIR: %d.\n", ACC_FIR);
                 int ROUND      = mode_bits.extract(38, 3).as_int();
+				log("ROUND: %d.\n", ROUND);
                 int ZC_SHIFT   = mode_bits.extract(41, 5).as_int();
+				log("ZC_SHIFT: %d.\n", ZC_SHIFT);
                 int ZREG_SHIFT = mode_bits.extract(46, 5).as_int();
+				log("ZREG_SHIFT: %d.\n", ZREG_SHIFT);
                 int SHIFT_REG  = mode_bits.extract(51, 6).as_int();
+				log("SHIFT_REG: %d.\n", SHIFT_REG);
                 
                 bool SATURATE  = mode_bits.extract(57).as_bool();
+				if (SATURATE)
+					log("STARUATE Enabled.\n");
                 bool SUBTRACT  = mode_bits.extract(58).as_bool();
+				if (SUBTRACT)
+					log("SUBTRACT Enabled.\n");
                 bool PRE_ADD   = mode_bits.extract(59).as_bool();
-                
+                if (PRE_ADD)
+					log("PRE_ADD Enabled.\n");
                 bool A_SEL     = mode_bits.extract(60).as_bool();
+				if (A_SEL)
+					log("A_SEL Enabled.\n");
                 bool A_REG     = mode_bits.extract(61).as_bool();
+				if (A_REG)
+					log("A_REG Enabled.\n");
                 bool A1_REG    = mode_bits.extract(62).as_bool();
+				if (A1_REG)
+					log("A1_REG Enabled.\n");
                 bool A2_REG    = mode_bits.extract(63).as_bool();
+				if (A2_REG)
+					log("A2_REG Enabled.\n");
 
                 bool B_SEL     = mode_bits.extract(64).as_bool();
+				if (B_SEL)
+					log("B_SEL Enabled.\n");
                 bool B_REG     = mode_bits.extract(65).as_bool();
+				if (B_REG)
+					log("B_REG Enabled.\n");
                 bool B1_REG    = mode_bits.extract(66).as_bool();
+				if (B1_REG)
+					log("B1_REG Enabled.\n");
                 bool B2_REG    = mode_bits.extract(67).as_bool();	
+				if (B2_REG)
+					log("B2_REG Enabled.\n");
 
                 bool C_REG     = mode_bits.extract(68).as_bool();
+				if (C_REG)
+					log("C_REG Enabled.\n");
                 bool BC_REG    = mode_bits.extract(69).as_bool();
+				if (BC_REG)
+					log("BC_REG Enabled.\n");
                 bool M_REG     = mode_bits.extract(70).as_bool();
+				if (M_REG)
+					log("M_REG Enabled.\n");
                 bool ZCIN_SEL  = mode_bits.extract(71).as_bool();
+				if (ZCIN_SEL)
+					log("ZCIN_SEL Enabled.\n");
                 bool ACOUT_SEL = mode_bits.extract(72).as_bool();
+				if (ACOUT_SEL)
+					log("ACOUT_SEL Enabled.\n");
                 bool BCOUT_SEL = mode_bits.extract(73).as_bool();
-
+				if (BCOUT_SEL)
+					log("BCOUT_SEL Enabled.\n");
                 bool FRAC_MODE = mode_bits.extract(79).as_bool();
+				if (FRAC_MODE)
+					log("FRAC_MODE Enabled.\n");
 
 				int FEEDBACK = get_const_port_value(cell, ID(feedback));
+				log("FEEDBACK: %d.\n", FEEDBACK);
 				int OUTPUT_SELECT = get_const_port_value(cell, ID(output_select));
+				log("OUTPUT_SELECT: %d.\n", OUTPUT_SELECT);
 				int LOAD_ACC = get_const_port_value(cell, ID(load_acc));
+				log("LOAD_ACC: %d.\n", LOAD_ACC);
+
+				replace_output_port_and_drop(
+						module,
+						cell,
+						RTLIL::IdString("\\z"),
+						RTLIL::IdString("\\z_cout")
+					);
 				
-				if (A_REG)
+				if (A1_REG && A2_REG) {
 					add_bitwise_dffre_before_cell_input(
 							module,
 							cell,
 							RTLIL::IdString("\\a")
 						);
-				
-				if (B_REG)
+					add_bitwise_dffre_before_cell_input(
+							module,
+							cell,
+							RTLIL::IdString("\\a")
+						);
+				}
+
+				else if (A2_REG || A_REG) {
+					add_bitwise_dffre_before_cell_input(
+							module,
+							cell,
+							RTLIL::IdString("\\a")
+						);
+				}
+
+				if (B1_REG && B2_REG) {
 					add_bitwise_dffre_before_cell_input(
 							module,
 							cell,
 							RTLIL::IdString("\\b")
 						);
-				
-				if (C_REG)
+					add_bitwise_dffre_before_cell_input(
+							module,
+							cell,
+							RTLIL::IdString("\\b")
+						);
+				}			
+				else if (B2_REG || B_REG) {
+					add_bitwise_dffre_before_cell_input(
+							module,
+							cell,
+							RTLIL::IdString("\\b")
+						);
+				}
+				if (C_REG) {
 					add_bitwise_dffre_before_cell_input(
 							module,
 							cell,
 							RTLIL::IdString("\\c")
 						);
-				
+				}
 				if (OUTPUT_SELECT >= 4)
 					add_bitwise_dffre_after_cell_output(
 						module,
@@ -306,7 +406,7 @@ struct QlDSPV2TypesPass : public Pass {
 						break;
 					
 					
-
+					case 0b010110000: //CONCAT_CASCADE									
 					case 0b010100000: //CONCAT_CASCADE
 						transform_cell_with_ports(cell,
 												  RTLIL::escape_id("QL_DSPV2_CONCAT_CASCADE"),
@@ -368,7 +468,7 @@ struct QlDSPV2TypesPass : public Pass {
 													});
 						break;
 
-					
+					case 0b011110100: //MULTADD
 					case 0b011100100: //MULTADD
 						transform_cell_with_ports(cell,
 												  RTLIL::escape_id("QL_DSPV2_MULTADD"),
@@ -382,7 +482,7 @@ struct QlDSPV2TypesPass : public Pass {
 													});
 						break;
 					
-					
+					case 0b011110101: //MULTADD_NEG
 					case 0b011100101: //MULTADD_NEG
 						transform_cell_with_ports(cell,
 												  RTLIL::escape_id("QL_DSPV2_MULTADD_NEG"),


### PR DESCRIPTION
This PR fixes some of the problems that were found in the DSPV2 Synthesis Pass.

Driving the signal driven by z_cout, by the signal that is driven by z when dropping z_cout port.
Input Pipeline registering fix.