### PR TITLE
add ABC9 script using &satlut

### DIFF
--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -35,6 +35,18 @@ struct SynthQuickLogicPass : public ScriptPass {
 
     SynthQuickLogicPass() : ScriptPass(STR(PASS_NAME), "Synthesis for QuickLogic FPGAs") {}
 
+    void on_register() override
+    {
+        // ABC9's &satlut pass has the limitation that it only works with LUT6s.
+        // This turns out to integrate nicely with k6n10f.
+        RTLIL::constpad["synth_quicklogic.abc9.script.default"] = "+&scorr; &sweep; &dc2; &dch -f -r; &ps; &if {W} {D} {R} -v; &mfs; &ps -l; &satlut -C 100000; &st -u";
+        RTLIL::constpad["synth_quicklogic.abc9.script.flow3"] = "+&scorr; &sweep;" \
+                "&if {W} {D}; &save; &st; &syn2; &if {W} {D} {R} -v; &save; &load;"\
+                "&st; &if -g -K 6; &dch -f; &if {W} {D} {R} -v; &save; &load;"\
+                "&st; &if -g -K 6; &synch2; &if {W} {D} {R} -v; &save; &load;"\
+                "&mfs; &ps -l; &satlut -C 100000; &st -u";
+    }
+
     void help() override
     {
         log("\n");
@@ -326,6 +338,10 @@ struct SynthQuickLogicPass : public ScriptPass {
             if (family == "qlf_k6n10f") {
                 design->scratchpad_set_int("abc9.W", 1000); // set interconnet delay as 1ns
             }
+        }
+
+        if (abc9 && family == "qlf_k6n10f" && design->scratchpad.count("abc9.script") == 0) {
+            design->scratchpad_set_string("abc9.script", RTLIL::constpad["synth_quicklogic.abc9.script.flow3"]);
         }
 
         log_header(design, "Executing SYNTH_QUICKLOGIC pass.\n");


### PR DESCRIPTION
On the `jpeg_top` benchmark, this script plus a `verific -cfg db_infer_wide_operators 0` before reading `jpeg_top.sv` results in about a 9% area reduction.

before:
```
        +----------Count including submodules.
        |
    13749 wires
   167237 wire bits
    13749 public wires
   167237 public wire bits
        9 ports
       67 port bits
        - memories
        - memory bits
        - processes
    22563 cells
    21997   $lut
       22   $scopeinfo
      533   QL_DSP2_MULT
       11   TDP36K
    50585 submodules
    17147   adder_carry
    33438   sdffsre
```

after:
```
        +----------Count including submodules.
        |
    19411 wires
   131332 wire bits
    19411 public wires
   131332 public wire bits
        9 ports
       67 port bits
        - memories
        - memory bits
        - processes
    20453 cells
    20167   $lut
       22   $scopeinfo
      253   QL_DSP2_MULT
       11   TDP36K
    46351 submodules
    12913   adder_carry
    33438   sdffsre
```