### PR TITLE
DSPv2 partial support: MULT/MULTACC inference on qlf_k6n10f

### DIFF
--- a/docs/dspv2/IMPLEMENTATION.md
+++ b/docs/dspv2/IMPLEMENTATION.md
@@ -1,0 +1,173 @@
+# DSPv2 Yosys-driven Synthesis Inference — Implementation
+
+**Document ID:** QL-PLUGIN-DSPV2-IMPL-001
+**Status:** Active
+**Requirements:** [REQUIREMENTS.md](REQUIREMENTS.md)
+**Reference:** [YosysHQ/yosys#4932](https://github.com/YosysHQ/yosys/pull/4932)
+**Branch:** `dspv2-partial-support` (from `origin/main`)
+
+---
+
+## 1. Change Inventory
+
+| File | Action | Notes |
+|------|--------|-------|
+| `ql-qlf-plugin/Makefile` | edit | adds `ql-dspv1.cc` / `ql-dspv2.cc` SOURCES + pmgen recipes; `VERILOG_MODULES` unchanged |
+| `ql-qlf-plugin/ql-dsp.cc` → `ql-qlf-plugin/ql-dspv1.cc` | rename + minor edit | pass `ql_dsp` → `ql_dspv1`, include `ql-dspv1-pm.h`; body otherwise identical |
+| `ql-qlf-plugin/ql_dsp.pmg` → `ql-qlf-plugin/ql-dspv1.pmg` | rename + minor edit | pattern `ql_dsp` → `ql_dspv1`; fixes underscore-name outlier (hyphen branding) |
+| `ql-qlf-plugin/ql-dspv2.cc` | **new** | byte-identical body to PR #4932 `ql_dsp.cc`; pass identifier suffixed `v2` |
+| `ql-qlf-plugin/ql-dspv2.pmg` | **new** | byte-identical body to PR #4932 `ql_dsp.pmg`; patterns suffixed `v2` |
+| `ql-qlf-plugin/synth_quicklogic.cc` | edit | drops Synplify-only V2 guard; gates `QL_DSPV2.v` read on `synplify && !dspv2`; adds V2 arm in `map_dsp`; `qlf_k6n10` arm pass call `ql_dsp` → `ql_dspv1` |
+| `ql-qlf-plugin/qlf_k6n10f/**` | **untouched** | identical to `origin/main` — V2 device files come from `device_data` under the same `dsp_*.v` filenames |
+
+No tests added in this release (see REQUIREMENTS.md §4.2).
+
+## 2. `synth_quicklogic.cc`
+
+### 2.1 Sim-library load (begin label)
+
+```cpp
+if (family == "qlf_k6n10f") {
+    readVelArgs += family_path + "/dsp_sim.v";   // same filename for V1 and V2
+    ...
+}
+...
+run("read_verilog -lib -specify -nomem2reg " + readVelArgs);
+if (synplify && !dspv2) {
+    // QL_DSPV2.v is only needed by the Synplify path on V1 devices.
+    run("read_verilog " + family_path + "/QL_DSPV2.v");
+}
+```
+
+The V1-vs-V2 selection happens entirely at the `device_data` install
+layer: each device's `qlf_k6n10f/dsp_sim.v` is either the V1 or the V2
+cell-model file under the same filename.
+
+### 2.2 `map_dsp` V2 arm
+
+```cpp
+if (dspv2) {
+    // Helpers reused unchanged from V1 in this release; the V2-specific
+    // -dspv2 extensions on ql_dsp_macc / ql_dsp_simd / ql_dsp_io_regs
+    // are deferred (see REQUIREMENTS.md §4.2).
+    //
+    // Same dsp_*.v filenames on both arms per device_data convention.
+    run("ql_dsp_macc");
+    run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
+        "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
+        "-D DSP_A_MAXWIDTH=32 -D DSP_B_MAXWIDTH=18 "
+        "-D DSP_A_MINWIDTH=10 -D DSP_B_MINWIDTH=10 "
+        "-D DSP_NAME=$__MUL32X18");
+    run("chtype -set $mul t:$__soft_mul");
+    run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
+        "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
+        "-D DSP_A_MAXWIDTH=16 -D DSP_B_MAXWIDTH=9 "
+        "-D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 "
+        "-D DSP_NAME=$__MUL16X9");
+    run("chtype -set $mul t:$__soft_mul");
+    run("ql_dspv2");
+    run("ql_dsp_simd");
+    run("techmap -map " + lib_path + family + "/dsp_final_map.v");
+    run("ql_dsp_io_regs");
+}
+```
+
+Width thresholds (10×10 min for 32×18; 4×4 for 16×9), module names
+(`$__MUL32X18`, `$__MUL16X9`), and the two-pass `mul2dsp` lowering are
+verbatim from PR #4932.
+
+### 2.3 `map_dsp` V1 arm
+
+Byte-identical to `origin/main`, except for the renamed pass call on
+the `qlf_k6n10` (non-`f`) branch (`ql_dsp` → `ql_dspv1`). All
+`qlf_k6n10f` V1-arm techmap calls (`dsp_map.v`, `dsp_final_map.v`) and
+helper-pass calls (`ql_dsp_macc`, `ql_dsp_simd`, `ql_dsp_io_regs`) are
+unchanged from main.
+
+## 3. `ql-dspv2.cc` / `ql-dspv2.pmg`
+
+Imported byte-identical (modulo identifier renaming) from PR #4932's
+`techlibs/quicklogic/ql_dsp.cc` and `ql_dsp.pmg`. Renames:
+
+| #4932 | This plugin |
+|-------|-------------|
+| pass `ql_dsp` | `ql_dspv2` |
+| C++ class `QlDspPass` | `QlDspv2Pass` |
+| pmg pattern `ql_dsp_pack_regs` | `ql_dspv2_pack_regs` |
+| pmg pattern `ql_dsp_cascade` | `ql_dspv2_cascade` |
+| pmgen class `ql_dsp_pm` | `ql_dspv2_pm` |
+| pmgen header `ql-dsp-pm.h` | `ql-dspv2-pm.h` |
+
+The `-nocascade` flag is preserved verbatim. Both pmg patterns stay
+active.
+
+## 4. `ql-dspv1.cc` / `ql-dspv1.pmg`
+
+Pure rename of `ql-dsp.cc` / `ql_dsp.pmg` (the latter also moves from
+underscore to hyphen naming to match the rest of the plugin: `ql-dsp-*`,
+`ql-bram-*`). Content edits:
+
+- `Pass("ql_dsp", ...)` → `Pass("ql_dspv1", ...)`
+- C++ class `QlDspPass` → `QlDspv1Pass` (helper functions / pm class
+  consistently suffixed `v1`)
+- `pattern ql_dsp` → `pattern ql_dspv1`
+- `#include "pmgen/ql-dsp-pm.h"` → `#include "pmgen/ql-dspv1-pm.h"`
+
+V1 inference behaviour is unchanged.
+
+## 5. Makefile
+
+```make
+SOURCES = synth_quicklogic.cc \
+-         ql-dsp.cc \
++         ql-dspv1.cc \
++         ql-dspv2.cc \
+          ...
+
+-DEPS := $(PMGEN_OUT_DIR)/ql-dsp-pm.h \
++DEPS := $(PMGEN_OUT_DIR)/ql-dspv1-pm.h \
++        $(PMGEN_OUT_DIR)/ql-dspv2-pm.h \
+         $(PMGEN_OUT_DIR)/ql-dsp-macc.h \
+         ...
+
+-$(PMGEN_OUT_DIR)/ql-dsp-pm.h: ql_dsp.pmg
+-       python3 $(PMGEN_PY) -o $@ -p ql_dsp ql_dsp.pmg
++$(PMGEN_OUT_DIR)/ql-dspv1-pm.h: ql-dspv1.pmg
++       python3 $(PMGEN_PY) -o $@ -p ql_dspv1 ql-dspv1.pmg
++
++$(PMGEN_OUT_DIR)/ql-dspv2-pm.h: ql-dspv2.pmg
++       python3 $(PMGEN_PY) -o $@ -p ql_dspv2 ql-dspv2.pmg
+```
+
+`VERILOG_MODULES` is **unchanged**: the plugin still ships `dsp_sim.v`,
+`dsp_map.v`, `dsp_final_map.v` (and the V1 cell models) exactly as on
+main. V2 cell content is supplied by `device_data` under the same
+filenames at install time per REQUIREMENTS.md §3.
+
+## 6. Commit Layout
+
+Four commits on `dspv2-partial-support`:
+
+1. `ql-qlf-plugin: rename v1 DSP namespace to ql_dspv1`
+2. `ql-qlf-plugin: import DSPv2 pass from YosysHQ/yosys#4932`
+3. `synth_quicklogic: drop Synplify-only -dspv2 guard; gate QL_DSPV2.v on synplify && !dspv2`
+4. `synth_quicklogic: wire DSPv2 arm in map_dsp for qlf_k6n10f`
+
+## 7. Validation
+
+| Step | Status |
+|------|--------|
+| Plugin build (`make -j` against Aurora `dev/share/yosys`) | ✅ clean (macOS clang) |
+| `ql-qlf-plugin/qlf_k6n10f/` diff vs `origin/main` | ✅ empty |
+| V1 path code structure vs `origin/main` | ✅ rename-only delta |
+| V2 pass body vs PR #4932 | ✅ byte-identical (modulo identifier suffix) |
+| Aurora `tests/` smoke | pending submodule pin bump + run |
+
+## 8. Workflow
+
+- All edits land in the standalone clone at
+  `Quicklogic-Corp/yosys-f4pga-plugins` on branch `dspv2-partial-support`
+  cut from `origin/main`.
+- After the plugin PR merges to `main`, the Aurora superproject's
+  submodule pointer is bumped on a separate Aurora PR.
+- No commits land in the nested submodule clone inside Aurora.

--- a/docs/dspv2/REQUIREMENTS.md
+++ b/docs/dspv2/REQUIREMENTS.md
@@ -1,0 +1,100 @@
+# DSPv2 Yosys-driven Synthesis Inference — Requirements
+
+**Document ID:** QL-PLUGIN-DSPV2-REQ-001
+**Status:** Active
+**Target family:** `qlf_k6n10f`
+**Plugin:** `ql-qlf-plugin`
+**Reference:** [YosysHQ/yosys#4932](https://github.com/YosysHQ/yosys/pull/4932) (povik/ql-dspv2)
+
+---
+
+## 1. Purpose
+
+Enable a Yosys-driven DSPv2 inference flow under
+`synth_quicklogic -family qlf_k6n10f -dspv2` **without** requiring the
+`-synplify` switch. The flow infers `QL_DSPV2` cells from generic RTL
+multiplies / multiply-accumulates / multiply-adds.
+
+## 2. DSPv1 Preservation (hard requirement)
+
+The V1 inference path shall remain **bit-identical** in behaviour. The
+release is permitted to rename the V1 pass and pmg source files into a
+`v1` namespace for symmetric naming with V2 (`ql-dsp.cc` → `ql-dspv1.cc`,
+`ql_dsp.pmg` → `ql-dspv1.pmg`, registered pass `ql_dsp` → `ql_dspv1`).
+No other V1 change is permitted.
+
+## 3. Device-Data Convention (hard requirement)
+
+Per-device Verilog files for `qlf_k6n10f` are owned by the Aurora
+`device_data` submodule. **V1 and V2 devices ship their cell library
+under the same filenames** — the per-device file *content* selects V1
+vs V2 behaviour:
+
+| Filename (same for V1 and V2) | Role |
+|-------------------------------|------|
+| `dsp_sim.v` | DSP simulation/cell-model library |
+| `dsp_map.v` | DSP techmap (used by `mul2dsp` lowering) |
+| `dsp_final_map.v` | Final-stage techmap (wrapper → hard cell) |
+
+`synth_quicklogic.cc` therefore references the same filenames on both
+the V1 and V2 arms. The plugin's own `ql-qlf-plugin/qlf_k6n10f/`
+directory shall remain byte-identical to `origin/main`; the plugin does
+not ship any V2-specific Verilog files of its own. `device_data`
+overrides the plugin's shipped copies at install time.
+
+## 4. Release Scope
+
+### 4.1 In scope
+
+| Item | Mechanism |
+|------|-----------|
+| `QL_DSPV2_MULT` (32×18 and 16×9) | `mul2dsp.v` + `dsp_map.v` (V2 content from `device_data`) |
+| `QL_DSPV2_MULTACC` / `QL_DSPV2_MULTADD` | `ql_dspv2` pmgen patterns (`ql_dspv2_pack_regs`, `ql_dspv2_cascade`) |
+| `_REGIN` / `_REGOUT` register absorption | `ql_dspv2_pack_regs` pmgen subpattern |
+| Final collapse to `QL_DSPV2` | `dsp_final_map.v` (V2 content from `device_data`) |
+| Subtype classification (`MULT` / `MULTACC` / `MULTADD` + `_REG*`) | `ql_dsp_io_regs` (V1 implementation, re-used unchanged) |
+
+### 4.2 Deferred to a follow-up release
+
+The following helper-pass extensions are **not** included in this
+release. The V2 arm calls `ql_dsp_macc`, `ql_dsp_simd`, and
+`ql_dsp_io_regs` with their V1 behaviour:
+
+- `-dspv2` flag on `ql-dsp-macc.cc`
+- `-dspv2` flag on `ql-dsp-simd.cc`
+- `-dspv2` flag (a.k.a. `ql_dsp_io_regs_pass_v2()`) on `ql-dsp-io-regs.cc`
+- DSPv2 test cases
+
+This produces structurally-correct `QL_DSPV2` cells for the common
+multiplier / MAC patterns. Subtype-classification fidelity on
+V2-encoding-specific edge cases is tracked with the deferred
+extensions.
+
+### 4.3 Out of scope (no plan)
+
+- ABC9 timing arcs for DSPv2
+- Modifications to the Synplify-driven DSPv2 path (`ql_dspv2_types`
+  pass remains untouched; it continues to handle Synplify input)
+- Pre-adder / M-reg / bigger-adder / bigger-mult / A-cascade /
+  B-cascade / chain-MAC inference
+
+## 5. Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| **FR-1** | `synth_quicklogic -family qlf_k6n10f -dspv2` shall be accepted with or without `-synplify`. |
+| **FR-2** | When `-dspv2` is set and `-synplify` is **not** set, the begin-label sim-load shall read `dsp_sim.v` (V2 content supplied by `device_data`). |
+| **FR-3** | `QL_DSPV2.v` shall be read only on the Synplify path **without** `-dspv2` (i.e. `synplify && !dspv2`). The Yosys-driven V2 inference flow does not require an additional `QL_DSPV2.v` read. |
+| **FR-4** | A new `ql_dspv2` pass shall be registered; its C++ body and pmg file are imported from PR #4932. The pass identifier is `ql_dspv2`; pmg pattern identifiers are `ql_dspv2_pack_regs` and `ql_dspv2_cascade`. The `-nocascade` flag is preserved. |
+| **FR-5** | The V2 arm of `map_dsp` (for `qlf_k6n10f`, `!nodsp`, `dspv2`) shall execute: `wreduce t:$mul` → `ql_dsp_macc` → `techmap +/mul2dsp.v -map dsp_map.v` (32×18) → `chtype` → `techmap +/mul2dsp.v -map dsp_map.v` (16×9) → `chtype` → `ql_dspv2` → `ql_dsp_simd` → `techmap -map dsp_final_map.v` → `ql_dsp_io_regs`. |
+| **FR-6** | The V1 arm of `map_dsp` shall be byte-identical to `origin/main`, except that the `qlf_k6n10` (non-`f`) branch invokes `ql_dspv1` (renamed from `ql_dsp`). |
+| **FR-7** | The plugin's `ql-qlf-plugin/qlf_k6n10f/` directory shall not be modified relative to `origin/main`. |
+| **FR-8** | The Makefile shall (a) add `ql-dspv1.cc` and `ql-dspv2.cc` to `SOURCES`, (b) add `ql-dspv1-pm.h` and `ql-dspv2-pm.h` to `DEPS`, and (c) add the corresponding pmgen recipes. `VERILOG_MODULES` shall be byte-identical to `origin/main`. |
+
+## 6. Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| **NF-1** | All existing V1 tests shall continue to pass unchanged. |
+| **NF-2** | `-dspv2` without `-synplify` shall not affect synthesis of non-DSP logic. |
+| **NF-3** | The plugin shall build on Linux (GCC 9+) and macOS (clang). |

--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -18,7 +18,7 @@ PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 NAME = ql-qlf
 SOURCES = synth_quicklogic.cc \
-          ql-dsp.cc \
+          ql-dspv1.cc \
           pp3_braminit.cc \
           quicklogic_eqn.cc \
           ql-edif.cc \
@@ -115,7 +115,7 @@ PMGEN_OUT_DIR := $(BUILD_DIR)/pmgen
 $(PMGEN_OUT_DIR):
 	mkdir -p $@
 
-DEPS := $(PMGEN_OUT_DIR)/ql-dsp-pm.h \
+DEPS := $(PMGEN_OUT_DIR)/ql-dspv1-pm.h \
         $(PMGEN_OUT_DIR)/ql-dsp-macc.h \
         $(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-write.h \
         $(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-read.h
@@ -124,8 +124,8 @@ $(DEPS): $(PMGEN_PY) | $(PMGEN_OUT_DIR)
 
 $(OBJECTS): $(DEPS)
 
-$(PMGEN_OUT_DIR)/ql-dsp-pm.h: ql_dsp.pmg
-	python3 $(PMGEN_PY) -o $@ -p ql_dsp ql_dsp.pmg
+$(PMGEN_OUT_DIR)/ql-dspv1-pm.h: ql-dspv1.pmg
+	python3 $(PMGEN_PY) -o $@ -p ql_dspv1 ql-dspv1.pmg
 
 $(PMGEN_OUT_DIR)/ql-dsp-macc.h: ql-dsp-macc.pmg
 	python3 $(PMGEN_PY) -o $@ -p ql_dsp_macc ql-dsp-macc.pmg

--- a/ql-qlf-plugin/Makefile
+++ b/ql-qlf-plugin/Makefile
@@ -19,6 +19,7 @@ PLUGIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 NAME = ql-qlf
 SOURCES = synth_quicklogic.cc \
           ql-dspv1.cc \
+          ql-dspv2.cc \
           pp3_braminit.cc \
           quicklogic_eqn.cc \
           ql-edif.cc \
@@ -116,6 +117,7 @@ $(PMGEN_OUT_DIR):
 	mkdir -p $@
 
 DEPS := $(PMGEN_OUT_DIR)/ql-dspv1-pm.h \
+        $(PMGEN_OUT_DIR)/ql-dspv2-pm.h \
         $(PMGEN_OUT_DIR)/ql-dsp-macc.h \
         $(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-write.h \
         $(PMGEN_OUT_DIR)/ql-bram-asymmetric-wider-read.h
@@ -126,6 +128,9 @@ $(OBJECTS): $(DEPS)
 
 $(PMGEN_OUT_DIR)/ql-dspv1-pm.h: ql-dspv1.pmg
 	python3 $(PMGEN_PY) -o $@ -p ql_dspv1 ql-dspv1.pmg
+
+$(PMGEN_OUT_DIR)/ql-dspv2-pm.h: ql-dspv2.pmg
+	python3 $(PMGEN_PY) -o $@ -p ql_dspv2 ql-dspv2.pmg
 
 $(PMGEN_OUT_DIR)/ql-dsp-macc.h: ql-dsp-macc.pmg
 	python3 $(PMGEN_PY) -o $@ -p ql_dsp_macc ql-dsp-macc.pmg

--- a/ql-qlf-plugin/ql-dsp-macc.cc
+++ b/ql-qlf-plugin/ql-dsp-macc.cc
@@ -10,7 +10,7 @@ PRIVATE_NAMESPACE_BEGIN
 
 bool use_dsp_cfg_params;
 
-static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
+static void create_ql_macc_dsp_v1(ql_dsp_macc_pm &pm)
 {
     auto &st = pm.st_ql_dsp_macc;
 
@@ -246,6 +246,191 @@ static void create_ql_macc_dsp(ql_dsp_macc_pm &pm)
     pm.autoremove(st.ff);
 }
 
+// ============================================================================
+// V2 variant: emits dspv2_NxMxK_cfg_ports cells (which techmap to QL_DSPV2,
+// later specialized by ql_dspv2_types). Ported from YosysHQ/yosys#4932.
+static void create_ql_macc_dsp_v2(ql_dsp_macc_pm &pm)
+{
+    auto &st = pm.st_ql_dsp_macc;
+
+    // Reject if multiplier drives anything else than either $add or $add and
+    // $mux (same gating as v1)
+    if (st.mux == nullptr && st.mul_nusers > 2) {
+        return;
+    }
+
+    bool out_ff;
+    if (st.ff_d_nusers == 2 && st.ff_q_nusers == 3) {
+        out_ff = true;
+    } else if (st.ff_d_nusers == 3 && st.ff_q_nusers == 2) {
+        out_ff = false;
+    } else {
+        return;
+    }
+
+    if (st.mux == nullptr) {
+        if (out_ff && st.add_nusers != 2)
+            return;
+        if (!out_ff && st.add_nusers != 3)
+            return;
+    } else {
+        if (st.add_nusers != 2)
+            return;
+    }
+
+    if (st.mux != nullptr) {
+        if (out_ff && st.mux_nusers != 2)
+            return;
+        if (!out_ff && st.mux_nusers != 3)
+            return;
+    }
+
+    if (st.ff->getParam(ID(CLK_POLARITY)).as_int() != 1) {
+        return;
+    }
+
+    // Gather operand widths
+    RTLIL::SigSpec sig_a = st.mul->getPort(ID(A));
+    RTLIL::SigSpec sig_b = st.mul->getPort(ID(B));
+    if (sig_a.size() < sig_b.size())
+        std::swap(sig_a, sig_b);
+
+    bool ab_signed = st.mul->getParam(ID(A_SIGNED)).as_bool();
+    log_assert(ab_signed == st.mul->getParam(ID(B_SIGNED)).as_bool());
+
+    int z_width = GetSize(st.ff->getPort(ID(Q)));
+    if (!ab_signed) {
+        if (sig_a.msb() != RTLIL::S0 && sig_a.size() < z_width)
+            sig_a.append(RTLIL::S0);
+        if (sig_b.msb() != RTLIL::S0 && sig_b.size() < z_width)
+            sig_b.append(RTLIL::S0);
+    }
+    int a_width = GetSize(sig_a);
+    int b_width = GetSize(sig_b);
+
+    // Determine DSPv2 cell size
+    RTLIL::IdString type;
+    size_t tgt_a_width;
+    size_t tgt_b_width;
+    size_t tgt_z_width;
+
+    string cell_base_name = "dspv2";
+    string cell_size_name;
+
+    if (a_width <= 2 && b_width <= 2 && z_width <= 4) {
+        return;
+    } else if (a_width <= 16 && b_width <= 9 && z_width <= 25) {
+        cell_size_name = "_16x9x32";
+        tgt_a_width = 16;
+        tgt_b_width = 9;
+        tgt_z_width = 25;
+    } else if (a_width <= 32 && b_width <= 18 && z_width <= 50) {
+        cell_size_name = "_32x18x64";
+        tgt_a_width = 32;
+        tgt_b_width = 18;
+        tgt_z_width = 50;
+    } else {
+        return;
+    }
+
+    type = RTLIL::escape_id(cell_base_name + cell_size_name + "_cfg_ports");
+    log("Inferring MACC %dx%d->%d as %s from:\n", a_width, b_width, z_width, RTLIL::unescape_id(type).c_str());
+
+    for (auto cell : {st.mul, st.add, st.mux, st.ff}) {
+        if (cell != nullptr) {
+            log(" %s (%s)\n", RTLIL::unescape_id(cell->name).c_str(), RTLIL::unescape_id(cell->type).c_str());
+        }
+    }
+
+    // Build the DSP cell name (consistent with v1 naming scheme)
+    std::string name;
+    name += RTLIL::unescape_id(st.mul->name) + "_";
+    name += RTLIL::unescape_id(st.add->name) + "_";
+    if (st.mux != nullptr) {
+        name += RTLIL::unescape_id(st.mux->name) + "_";
+    }
+    name += RTLIL::unescape_id(st.ff->name);
+
+    RTLIL::Cell *cell = pm.module->addCell(RTLIL::escape_id(name), type);
+    cell->set_bool_attribute(RTLIL::escape_id("is_inferred"), true);
+
+    RTLIL::SigSpec sig_z = out_ff ? st.ff->getPort(ID(Q)) : st.ff->getPort(ID(D));
+
+    // Connect input data ports, sign-extend
+    sig_a.extend_u0(tgt_a_width, true);
+    sig_b.extend_u0(tgt_b_width, true);
+    cell->setPort(RTLIL::escape_id("a_i"), sig_a);
+    cell->setPort(RTLIL::escape_id("b_i"), sig_b);
+    cell->setPort(RTLIL::escape_id("c_i"), RTLIL::SigSpec(RTLIL::S0, tgt_b_width));
+
+    // Connect output data port, pad if needed
+    if ((size_t)GetSize(sig_z) < tgt_z_width) {
+        auto *wire = pm.module->addWire(NEW_ID, tgt_z_width - GetSize(sig_z));
+        sig_z.append(wire);
+    }
+    cell->setPort(RTLIL::escape_id("z_o"), sig_z);
+
+    // Connect clock / reset / enable
+    cell->setPort(RTLIL::escape_id("clock_i"), st.ff->getPort(ID(CLK)));
+
+    RTLIL::SigSpec rst;
+    RTLIL::SigSpec ena;
+
+    if (st.ff->hasPort(ID(ARST))) {
+        if (st.ff->getParam(ID(ARST_POLARITY)).as_int() != 1) {
+            rst = pm.module->Not(NEW_ID, st.ff->getPort(ID(ARST)));
+        } else {
+            rst = st.ff->getPort(ID(ARST));
+        }
+    } else {
+        rst = RTLIL::SigSpec(RTLIL::S0);
+    }
+
+    if (st.ff->hasPort(ID(EN))) {
+        if (st.ff->getParam(ID(EN_POLARITY)).as_int() != 1) {
+            ena = pm.module->Not(NEW_ID, st.ff->getPort(ID(EN)));
+        } else {
+            ena = st.ff->getPort(ID(EN));
+        }
+    } else {
+        ena = RTLIL::SigSpec(RTLIL::S1);
+    }
+
+    cell->setPort(RTLIL::escape_id("reset_i"), rst);
+    cell->setPort(RTLIL::escape_id("load_acc_i"), ena);
+    cell->setPort(RTLIL::escape_id("acc_reset_i"), RTLIL::SigSpec(RTLIL::S0));
+
+    // Insert feedback_i control logic used for clearing / loading the accumulator
+    if (st.mux != nullptr) {
+        RTLIL::SigSpec sig_s = st.mux->getPort(ID(S));
+
+        log_assert(st.mux_ab == ID(A) || st.mux_ab == ID(B));
+        if (st.mux_ab == ID(A)) {
+            sig_s = pm.module->Not(NEW_ID, sig_s);
+        }
+
+        // V2 feedback bit ordering differs from V1: {S0, S0, sig_s}
+        cell->setPort(RTLIL::escape_id("feedback_i"), {RTLIL::S0, RTLIL::S0, sig_s});
+    } else {
+        cell->setPort(RTLIL::escape_id("feedback_i"), RTLIL::SigSpec(RTLIL::S0, 3));
+    }
+
+    // 3 - output post acc; 1 - output pre acc
+    cell->setPort(RTLIL::escape_id("output_select_i"), out_ff ? RTLIL::Const(1, 3) : RTLIL::Const(3, 3));
+
+    // V2 carries SUBTRACT as a parameter, not a port
+    bool subtract = (st.add->type == RTLIL::escape_id("$sub"));
+    cell->setParam(RTLIL::escape_id("SUBTRACT"), RTLIL::Const(subtract ? RTLIL::S1 : RTLIL::S0));
+
+    // Mark the cells for removal
+    pm.autoremove(st.mul);
+    pm.autoremove(st.add);
+    if (st.mux != nullptr) {
+        pm.autoremove(st.mux);
+    }
+    pm.autoremove(st.ff);
+}
+
 struct QlDspMacc : public Pass {
 
     QlDspMacc() : Pass("ql_dsp_macc", "Does something") {}
@@ -258,6 +443,9 @@ struct QlDspMacc : public Pass {
         log("    -use_dsp_cfg_params\n");
         log("        By default use DSP blocks with configuration bits available at module ports.\n");
         log("        Specifying this forces usage of DSP block with configuration bits available as module parameters\n");
+        log("\n");
+        log("    -dspv2\n");
+        log("        Target DSPv2 (dspv2_NxMxK_cfg_ports cells). Default targets DSPv1.\n");
         log("\n");
     }
 
@@ -272,10 +460,15 @@ struct QlDspMacc : public Pass {
     {
         log_header(a_Design, "Executing QL_DSP_MACC pass.\n");
 
+        bool target_dspv2 = false;
         size_t argidx;
         for (argidx = 1; argidx < a_Args.size(); argidx++) {
             if (a_Args[argidx] == "-use_dsp_cfg_params") {
                 use_dsp_cfg_params = true;
+                continue;
+            }
+            if (a_Args[argidx] == "-dspv2") {
+                target_dspv2 = true;
                 continue;
             }
 
@@ -284,7 +477,11 @@ struct QlDspMacc : public Pass {
         extra_args(a_Args, argidx, a_Design);
 
         for (auto module : a_Design->selected_modules()) {
-            ql_dsp_macc_pm(module, module->selected_cells()).run_ql_dsp_macc(create_ql_macc_dsp);
+            ql_dsp_macc_pm pm(module, module->selected_cells());
+            if (target_dspv2)
+                pm.run_ql_dsp_macc(create_ql_macc_dsp_v2);
+            else
+                pm.run_ql_dsp_macc(create_ql_macc_dsp_v1);
         }
     }
 

--- a/ql-qlf-plugin/ql-dsp-macc.cc
+++ b/ql-qlf-plugin/ql-dsp-macc.cc
@@ -409,7 +409,6 @@ static void create_ql_macc_dsp_v2(ql_dsp_macc_pm &pm)
             sig_s = pm.module->Not(NEW_ID, sig_s);
         }
 
-        // V2 feedback bit ordering differs from V1: {S0, S0, sig_s}
         cell->setPort(RTLIL::escape_id("feedback_i"), {RTLIL::S0, RTLIL::S0, sig_s});
     } else {
         cell->setPort(RTLIL::escape_id("feedback_i"), RTLIL::SigSpec(RTLIL::S0, 3));

--- a/ql-qlf-plugin/ql-dspv1.cc
+++ b/ql-qlf-plugin/ql-dspv1.cc
@@ -23,11 +23,11 @@
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
 
-#include "pmgen/ql-dsp-pm.h"
+#include "pmgen/ql-dspv1-pm.h"
 
-void create_ql_dsp(ql_dsp_pm &pm)
+void create_ql_dspv1(ql_dspv1_pm &pm)
 {
-    auto &st = pm.st_ql_dsp;
+    auto &st = pm.st_ql_dspv1;
 
     log("Checking %s.%s for QL DSP inference.\n", log_id(pm.module), log_id(st.mul));
 
@@ -127,14 +127,14 @@ void create_ql_dsp(ql_dsp_pm &pm)
     pm.autoremove(st.add);
 }
 
-struct QlDspPass : public Pass {
-    QlDspPass() : Pass("ql_dsp", "ql: map multipliers") {}
+struct QlDspv1Pass : public Pass {
+    QlDspv1Pass() : Pass("ql_dspv1", "ql: map multipliers (DSPv1)") {}
 
     void help() override
     {
         //   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
         log("\n");
-        log("    ql_dsp [options] [selection]\n");
+        log("    ql_dspv1 [options] [selection]\n");
         log("\n");
         log("Map multipliers ($mul/QL_DSP) and multiply-accumulate ($mul/QL_DSP + $add)\n");
         log("cells into ql DSP resources.\n");
@@ -155,7 +155,7 @@ struct QlDspPass : public Pass {
 
     void execute(std::vector<std::string> args, RTLIL::Design *design) override
     {
-        log_header(design, "Executing ql_DSP pass (map multipliers).\n");
+        log_header(design, "Executing ql_dspv1 pass (map multipliers).\n");
 
         size_t argidx;
         for (argidx = 1; argidx < args.size(); argidx++) {
@@ -164,8 +164,8 @@ struct QlDspPass : public Pass {
         extra_args(args, argidx, design);
 
         for (auto module : design->selected_modules())
-            ql_dsp_pm(module, module->selected_cells()).run_ql_dsp(create_ql_dsp);
+            ql_dspv1_pm(module, module->selected_cells()).run_ql_dspv1(create_ql_dspv1);
     }
-} QlDspPass;
+} QlDspv1Pass;
 
 PRIVATE_NAMESPACE_END

--- a/ql-qlf-plugin/ql-dspv1.pmg
+++ b/ql-qlf-plugin/ql-dspv1.pmg
@@ -1,4 +1,4 @@
-pattern ql_dsp
+pattern ql_dspv1
 
 state <SigBit> clock
 state <bool> clock_pol cd_signed o_lo

--- a/ql-qlf-plugin/ql-dspv2.cc
+++ b/ql-qlf-plugin/ql-dspv2.cc
@@ -1,0 +1,134 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/rtlil.h"
+#include "kernel/register.h"
+#include "kernel/sigtools.h"
+
+PRIVATE_NAMESPACE_BEGIN
+USING_YOSYS_NAMESPACE
+
+// promote dspv2_16x9x32_cfg_ports to dspv2_32x18x64_cfg_ports if need be
+bool promote(Module *m, Cell *cell) {
+	if (cell->type == ID(dspv2_32x18x64_cfg_ports)) {
+		return false;
+	} else {
+		log_assert(cell->type == ID(dspv2_16x9x32_cfg_ports));
+	}
+
+	auto widen_output = [&](IdString port_name, int new_width) {
+		if (!cell->hasPort(port_name))
+			return;
+		SigSpec port = cell->getPort(port_name);
+		if (port.size() < new_width) {
+			port = {m->addWire(NEW_ID, new_width - port.size()), port};
+			cell->setPort(port_name, port);
+		}
+	};
+
+	auto widen_input = [&](IdString port_name, int new_width) {
+		if (!cell->hasPort(port_name))
+			return;
+		SigSpec port = cell->getPort(port_name);
+		if (port.size() < new_width) {
+			port.extend_u0(new_width, /* is_signed= */ true);
+			cell->setPort(port_name, port);
+		}
+	};
+
+	widen_output(ID(z_o), 50);
+	widen_output(ID(a_cout_o), 32);
+	widen_output(ID(b_cout_o), 18);
+	widen_output(ID(z_cout_o), 50);
+
+	auto uses_port = [&](IdString port_name) {
+		return cell->hasPort(port_name) && !cell->getPort(port_name).is_fully_undef();
+	};
+
+	if (uses_port(ID(a_cin_i)) || uses_port(ID(b_cin_i)) || uses_port(ID(z_cin_i))) {
+		log_error("Cannot promote %s (type %s) with cascading paths\n", log_id(cell), log_id(cell->type));
+	}
+
+	widen_input(ID(a_i), 32);
+	widen_input(ID(b_i), 18);
+	widen_input(ID(c_i), 18);
+	cell->type = ID(dspv2_32x18x64_cfg_ports);
+	return true;
+}
+
+bool did_something;
+
+#include "pmgen/ql-dspv2-pm.h"
+
+struct QlDspv2Pass : Pass {
+	QlDspv2Pass() : Pass("ql_dspv2", "pack into QuickLogic DSPv2") {}
+
+	void help() override
+	{
+		//   |---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|---v---|
+		log("\n");
+		log("    ql_dspv2 [selection]\n");
+		log("\n");
+		log("This pass packs input and output path registers into QuickLogic DSP blocks,\n");
+		log("additionally it supports Z path cascading and post-adder packing.\n");
+		log("\n");
+		log("    -nocascade\n");
+		log("        forbid cascading\n");
+		log("\n");
+		
+	}
+
+	void execute(std::vector<std::string> args, RTLIL::Design *d) override
+	{
+		log_header(d, "Executing QL_DSPv2 pass. (pack into QuickLogic DSPv2)\n");
+
+		bool nocascade = false;
+		size_t argidx;
+		for (argidx = 1; argidx < args.size(); argidx++) {
+			if (args[argidx] == "-nocascade") {
+				nocascade = true;
+				continue;
+			}
+			break;
+		}
+		extra_args(args, argidx, d);
+
+		for (auto module : d->selected_modules()) {
+			did_something = true;
+
+			while (did_something)
+			{
+				// TODO: could be optimized by more reuse of the pmgen object
+				did_something = false;
+				{
+					ql_dspv2_pm pm(module, module->selected_cells());
+					pm.run_ql_dspv2_pack_regs();
+				}
+				if (!nocascade) {
+					ql_dspv2_pm pm(module, module->selected_cells());
+					pm.run_ql_dspv2_cascade();
+				}
+				{
+					ql_dspv2_pm pm(module, module->selected_cells());
+					pm.run_ql_dspv2_pack_regs();
+				}
+			}
+		}
+	}
+} QlDspv2Pass;
+
+PRIVATE_NAMESPACE_END

--- a/ql-qlf-plugin/ql-dspv2.pmg
+++ b/ql-qlf-plugin/ql-dspv2.pmg
@@ -1,0 +1,272 @@
+// derived from passes/pmgen/xilinx_dsp.pmg
+pattern ql_dspv2_pack_regs
+
+state <SigBit> clock reset
+state <bool> clock_inferred
+
+// Variables used for subpatterns
+state <SigSpec> argQ argD
+udata <SigSpec> dffD dffQ
+udata <SigBit> dffclock dffreset
+udata <Cell*> dff
+
+match dsp
+	select dsp->type.in(\dspv2_32x18x64_cfg_ports, \dspv2_16x9x32_cfg_ports)
+endmatch
+
+code clock_inferred clock reset
+	clock_inferred = false;
+	clock = port(dsp, \clock_i);
+	reset = port(dsp, \reset_i);
+endcode
+
+// try packing on Z output
+code argD clock_inferred clock reset
+	if (port(dsp, \output_select_i)[2] == RTLIL::S0 &&
+			(!dsp->hasPort(\z_cout_o) || nusers(port(dsp, \z_cout_o)) == 1) &&
+			nusers(port(dsp, \z_o)) == 2) {
+		argD = port(dsp, \z_o);
+		subpattern(out_dffe);
+		if (dff) {
+			clock_inferred = true;
+			clock = dffclock;
+			reset = dffreset;
+			log("%s: inferring Z path register from flip-flop %s\n", log_id(dsp), log_id(dff));
+			dsp->connections_[\output_select_i][2] = RTLIL::S1;
+			dsp->setPort(\z_o, dffQ);
+			did_something = true;
+		}
+	}
+endcode
+
+// try packing on B input
+code argQ clock_inferred clock reset
+	if ((!dsp->hasPort(\b_cout_o) || nusers(port(dsp, \b_cout_o)) == 1) &&
+			!param(dsp, \B_REG).as_bool()) {
+		argQ = port(dsp, \b_i);
+		subpattern(in_dffe);
+		if (dff) {
+			clock_inferred = true;
+			clock = dffclock;
+			reset = dffreset;
+			log("%s: inferring B path register from flip-flop %s\n", log_id(dsp), log_id(dff));
+			dsp->parameters[\B_REG] = Const(1, 1);
+			dsp->setPort(\b_i, dffD);
+			did_something = true;
+		}
+	}
+endcode
+
+// try packing on A input
+code argQ clock_inferred clock reset
+	if ((!dsp->hasPort(\a_cout_o) || nusers(port(dsp, \a_cout_o)) == 1) &&
+			!param(dsp, \A_REG).as_bool()) {
+		argQ = port(dsp, \a_i);
+		subpattern(in_dffe);
+		if (dff) {
+			clock_inferred = true;
+			clock = dffclock;
+			reset = dffreset;
+			log("%s: inferring A path register from flip-flop %s\n", log_id(dsp), log_id(dff));
+			dsp->parameters[\A_REG] = Const(1, 1);
+			dsp->setPort(\a_i, dffD);
+			did_something = true;
+		}
+	}
+endcode
+
+code
+	if (clock_inferred) {
+		dsp->setPort(\clock_i, clock);
+		dsp->setPort(\reset_i, reset);
+	}
+endcode
+
+// #######################
+// Subpattern for matching against input registers, based on knowledge of the
+//   'Q' output.
+subpattern in_dffe
+arg argQ clock reset
+
+code
+	dff = nullptr;
+	if (argQ.empty())
+		reject;
+	for (const auto &c : argQ.chunks()) {
+		if (!c.wire) {
+			// Abandon matches when constant Q bits are non-zero
+			// (doesn't match DSPv2 init/reset behavior)
+			if (!SigSpec(c).is_fully_zero())
+				reject;
+			continue;
+		}
+
+		// Abandon matches when 'Q' has the keep attribute set
+		if (c.wire->get_bool_attribute(\keep))
+			reject;
+		// Abandon matches when 'Q' has a non-zero init attribute set (not supported by DSPv2)
+		Const init = c.wire->attributes.at(\init, Const());
+		if (!init.empty())
+			for (auto b : init.extract(c.offset, c.width))
+				if (b != State::Sx && b != State::S0)
+					reject;
+	}
+endcode
+
+match ff
+	select ff->type.in($dff, $dffe, $adff, $adffe)
+	// DSPv2 does not support polarity inversion
+	select param(ff, \CLK_POLARITY).as_bool()
+
+	// Check that reset value, if present, is fully 0.
+	filter ff->type.in($dff, $dffe) || param(ff, \ARST_VALUE).is_fully_zero()
+
+	// Check reset polarity, if present
+	filter ff->type.in($dff, $dffe) || param(ff, \ARST_POLARITY).as_bool()
+
+	// Check that the LSB argQ bit is present (the rest follow by the nusers(...)=2 condition)
+	slice offset GetSize(port(ff, \D))
+	index <SigBit> port(ff, \Q)[offset] === argQ[0]
+
+	define <SigBit> ff_reset (ff->type.in($dff, $dffe) ? RTLIL::S0 : port(ff, \ARST))
+	filter clock == RTLIL::Sx || port(ff, \CLK)[0] == clock
+	filter clock == RTLIL::Sx || ff_reset == reset
+endmatch
+
+code argD
+	dff = ff;
+	dffclock = port(ff, \CLK);
+	dffreset = (ff->type.in($dff, $dffe) ? RTLIL::S0 : port(ff, \ARST));
+	dffD = argQ;
+	dffD.replace(port(ff, \Q), port(ff, \D));
+endcode
+
+
+// #######################
+// Subpattern for matching against output registers, based on knowledge of the
+//   'D' input.
+
+subpattern out_dffe
+arg argD clock reset
+
+code
+	dff = nullptr;
+	if (argD.empty())
+		reject;
+	for (const auto &c : argD.chunks()) {
+		// Abandon matches when 'D' has the keep attribute set
+		if (!c.wire || c.wire->get_bool_attribute(\keep))
+			reject;
+	}
+endcode
+
+match ff
+	select ff->type.in($dff, $dffe, $adff, $adffe)
+	// DSPv2 does not support polarity inversion
+	select param(ff, \CLK_POLARITY).as_bool()
+
+	// Check that reset value, if present, is fully 0.
+	filter ff->type.in($dff, $dffe) || param(ff, \ARST_VALUE).is_fully_zero()
+
+	// Check reset polarity, if present
+	filter ff->type.in($dff, $dffe) || param(ff, \ARST_POLARITY).as_bool()
+
+	slice offset GetSize(port(ff, \D))
+	index <SigBit> port(ff, \D)[offset] === argD[0]
+
+	define <SigBit> ff_reset (ff->type.in($dff, $dffe) ? RTLIL::S0 : port(ff, \ARST))
+	filter clock == RTLIL::Sx || port(ff, \CLK)[0] == clock
+	filter clock == RTLIL::Sx || ff_reset == reset
+endmatch
+
+code
+	dff = ff;
+	dffclock = port(ff, \CLK);
+	dffreset = (ff->type.in($dff, $dffe) ? RTLIL::S0 : port(ff, \ARST));
+	dffQ = argD;
+	dffQ.replace(port(ff, \D), port(ff, \Q));
+
+	// Abandon matches when 'Q' has a defined init attribute set
+	// (not supported by DSPv2)
+	for (auto c : dffQ.chunks()) {
+		Const init = c.wire->attributes.at(\init, Const());
+		if (!init.empty())
+			for (auto b : init.extract(c.offset, c.width))
+				if (b != State::Sx)
+					reject;
+	}
+
+	{
+		// Rewire retired flip-flop slice
+		SigSpec D = port(ff, \D);
+		SigSpec Q = port(ff, \Q);
+		D.replace(argD, module->addWire(NEW_ID, argD.size()), &Q);
+		D.replace(argD, Const(RTLIL::Sx, argD.size()));
+		ff->setPort(\D, D);
+		ff->setPort(\Q, Q);
+	}
+endcode
+
+pattern ql_dspv2_cascade
+
+match dsp1
+	select dsp1->type.in(\dspv2_32x18x64_cfg_ports, \dspv2_16x9x32_cfg_ports)
+	filter !dsp1->hasPort(\z_cout_o) || nusers(port(dsp1, \z_cout_o)) == 1
+endmatch
+
+match dsp2
+	select dsp2->type.in(\dspv2_32x18x64_cfg_ports, \dspv2_16x9x32_cfg_ports)
+	filter port(dsp2, \output_select_i).is_fully_const()
+	define <int> output_sel port(dsp2, \output_select_i).as_int()
+	filter output_sel == 0 || (output_sel == 4 && !param(dsp2, \M_REG).as_bool())
+	// expect `dsp2` and `add` for exclusive users
+	filter nusers(port(dsp2, \z_o)) == 2
+	filter !dsp2->hasPort(\z_cout_o) || nusers(port(dsp2, \z_cout_o)) == 1
+	filter dsp1 != dsp2
+endmatch
+
+match add
+	select add->type.in($add, $sub)
+	define <int> width param(add, \Y_WIDTH).as_int()
+
+	index <SigBit> port(add, \A)[0] === port(dsp1, \z_o)[0]
+	filter port(add, \A).size() >= width && port(dsp1, \z_o).size() >= width
+	filter port(add, \A).extract(0, width) == port(dsp1, \z_o).extract(0, width)
+
+	index <SigBit> port(add, \B)[0] === port(dsp2, \z_o)[0]
+	filter port(add, \B).size() >= width && port(dsp2, \z_o).size() >= width
+	filter port(add, \B).extract(0, width) == port(dsp2, \z_o).extract(0, width)
+endmatch
+
+code
+	const int z_width = 50;
+
+	log("%s: inferring post-adder from %s (type %s)\n", log_id(dsp2), log_id(add), log_id(add->type));
+	if (promote(module, dsp1))
+		log(" - promoting %s to non-fractured DSP block\n", log_id(dsp1));
+	if (promote(module, dsp2))
+		log(" - promoting %s to non-fractured DSP block\n", log_id(dsp2));
+
+	// link up z_cout_o of dsp1 to z_cin_i of dsp2
+	Wire *link = module->addWire(NEW_ID, z_width);
+	dsp1->setPort(\z_cout_o, link);
+	dsp2->setPort(\z_cin_i, link);
+
+	// configure the path inside dsp2
+	if (port(dsp2, \output_select_i).as_int() == 4) {
+		log("%s: inferring M register\n", log_id(dsp2));
+		dsp2->setParam(\M_REG, Const(1, 1));
+	}
+	dsp2->setParam(\SUBTRACT, Const(add->type == $sub, 1));
+	dsp2->setPort(\feedback_i, Const(3, 3));
+	dsp2->setPort(\output_select_i, Const(3, 3));
+	dsp2->setParam(\ROUND, Const(0, 3));
+	dsp2->setParam(\SHIFT_REG, Const(0, 6));
+	dsp2->setParam(\SATURATE, Const(0, 1));
+	dsp2->setParam(\ZCIN_REG, Const(1, 1));
+	dsp2->setPort(\z_o, {port(dsp2, \z_o).extract_end(port(add, \Y).size()), port(add, \Y)});
+
+	did_something = true;
+	autoremove(add);
+	accept;
+endcode

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -511,8 +511,6 @@ struct SynthQuickLogicPass : public ScriptPass {
             }
         }
 
-        run("ql_dspv2_types");
-
         if (check_label("map_dsp"), "(skip if -no_dsp)") {
             if (help_mode || family == "qlf_k6n10") {
                 if (help_mode || !nodsp) {
@@ -627,6 +625,12 @@ struct SynthQuickLogicPass : public ScriptPass {
                         run("techmap -map " + lib_path + family + "/dsp_final_map.v");
                         run("ql_dsp_io_regs");
                     }
+                    // Converts generic QL_DSPV2 cells (emitted by dsp_final_map.v on
+                    // V2 devices) into mode-specific subtypes (QL_DSPV2_MULT/
+                    // MULTACC/MULTADD with REGIN/REGOUT variants). No-op on V1
+                    // designs (no QL_DSPV2 cells present), so safe to run on both
+                    // arms.
+                    run("ql_dspv2_types");
                 }
             }
         }

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -588,7 +588,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                         // `dsp_final_map.v`); the per-device file content selects
                         // V1 vs V2 behaviour. We therefore reference the same
                         // filenames on both arms here.
-                        run("ql_dsp_macc");
+                        run("ql_dsp_macc -dspv2");
                         run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
                             "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
                             "-D DSP_A_MAXWIDTH=32 -D DSP_B_MAXWIDTH=18 "

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -593,13 +593,13 @@ struct SynthQuickLogicPass : public ScriptPass {
                             "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
                             "-D DSP_A_MAXWIDTH=32 -D DSP_B_MAXWIDTH=18 "
                             "-D DSP_A_MINWIDTH=10 -D DSP_B_MINWIDTH=10 "
-                            "-D DSP_NAME=$__MUL32X18");
+                            "-D DSP_NAME=$__QL_MUL32X18");
                         run("chtype -set $mul t:$__soft_mul");
                         run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
                             "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
                             "-D DSP_A_MAXWIDTH=16 -D DSP_B_MAXWIDTH=9 "
                             "-D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 "
-                            "-D DSP_NAME=$__MUL16X9");
+                            "-D DSP_NAME=$__QL_MUL16X9");
                         run("chtype -set $mul t:$__soft_mul");
                         // Deferred for this release — see comment above.
                         // run("ql_dspv2");

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -446,7 +446,7 @@ struct SynthQuickLogicPass : public ScriptPass {
             // Read simulation library
             readVelArgs = family_path + "/cells_sim.v";
             if (family == "qlf_k6n10f") {
-                readVelArgs += family_path + "/dsp_sim.v";
+                readVelArgs += family_path + (dspv2 ? "/dspv2_sim.v" : "/dsp_sim.v");
                 if(inferBram) {
                     readVelArgs += family_path + "/brams_sim.v";
                     if (bramTypes) {

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -446,9 +446,6 @@ struct SynthQuickLogicPass : public ScriptPass {
             // Read simulation library
             readVelArgs = family_path + "/cells_sim.v";
             if (family == "qlf_k6n10f") {
-                if(!synplify && dspv2) {
-                    log_cmd_error("DSPV2 is only supported with Synplify.\nPlease use Synplify as your synthesis tool.\n");
-                }
 				if (dspv2) {
 					readVelArgs += family_path + "/dspv2_sim.v";
 				}
@@ -470,7 +467,7 @@ struct SynthQuickLogicPass : public ScriptPass {
             // some block ram cell models. After all the only part of the cells
             // library required here is cell port definitions plus specify blocks.
             run("read_verilog -lib -specify -nomem2reg " + readVelArgs);
-			if (synplify) {
+			if (synplify && !dspv2) {
 			    run("read_verilog " + family_path + "/QL_DSPV2.v");
 			}
             run(stringf("hierarchy -check %s", help_mode ? "-top <top>" : top_opt.c_str()));

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -571,11 +571,18 @@ struct SynthQuickLogicPass : public ScriptPass {
                     if (dspv2) {
                         // DSPv2 arm — ported from YosysHQ/yosys#4932
                         // (povik/ql-dspv2 @ c68fd85b9ccceb773a4aaac2a35f7d90fbb15fc8).
-                        // Uses wider 32x18 and 16x9 multiplier shapes and the V2
-                        // pmgen pass (ql_dspv2). The ql_dsp_macc / ql_dsp_simd /
-                        // ql_dsp_io_regs helpers are re-used unchanged from V1
-                        // in this release; V2-specific helper-pass extensions
-                        // (the `-dspv2` flag on each) are deferred.
+                        // Uses wider 32x18 and 16x9 multiplier shapes via mul2dsp +
+                        // dsp_map.v techmap, followed by MULTACC inference via
+                        // ql_dsp_macc.
+                        //
+                        // Scope for this release (per PR #52 review): support is
+                        // limited to basic MULT (and MULTACC via ql_dsp_macc).
+                        // The cascade/register-packing pass (ql_dspv2), SIMD
+                        // packing (ql_dsp_simd) and IO-register packing
+                        // (ql_dsp_io_regs) are intentionally commented out and
+                        // deferred to a follow-up. Keeping them as commented
+                        // call sites preserves the #4932 pipeline shape for
+                        // easy re-enable.
                         //
                         // Device-data convention (Aurora `device_data` submodule):
                         // V1 and V2 devices ship their cell library under the
@@ -596,10 +603,11 @@ struct SynthQuickLogicPass : public ScriptPass {
                             "-D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 "
                             "-D DSP_NAME=$__MUL16X9");
                         run("chtype -set $mul t:$__soft_mul");
-                        run("ql_dspv2");
-                        run("ql_dsp_simd");
+                        // Deferred for this release — see comment above.
+                        // run("ql_dspv2");
+                        // run("ql_dsp_simd");
                         run("techmap -map " + lib_path + family + "/dsp_final_map.v");
-                        run("ql_dsp_io_regs");
+                        // run("ql_dsp_io_regs");
                     } else {
                         run("ql_dsp_macc" + use_dsp_cfg_params);
 

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -446,12 +446,7 @@ struct SynthQuickLogicPass : public ScriptPass {
             // Read simulation library
             readVelArgs = family_path + "/cells_sim.v";
             if (family == "qlf_k6n10f") {
-				if (dspv2) {
-					readVelArgs += family_path + "/dspv2_sim.v";
-				}
-				else {
-					readVelArgs += family_path + "/dsp_sim.v";
-				}
+                readVelArgs += family_path + "/dsp_sim.v";
                 if(inferBram) {
                     readVelArgs += family_path + "/brams_sim.v";
                     if (bramTypes) {
@@ -572,23 +567,58 @@ struct SynthQuickLogicPass : public ScriptPass {
                 } else if (!nodsp) {
 
                     run("wreduce t:$mul");
-                    run("ql_dsp_macc" + use_dsp_cfg_params);
 
-                    for (const auto &rule : dsp_rules) {
-                        run(stringf("techmap -map +/mul2dsp.v "
-                                    "-D DSP_A_MAXWIDTH=%zu -D DSP_B_MAXWIDTH=%zu "
-                                    "-D DSP_A_MINWIDTH=%zu -D DSP_B_MINWIDTH=%zu "
-                                    "-D DSP_NAME=%s",
-                                    rule.a_maxwidth, rule.b_maxwidth, rule.a_minwidth, rule.b_minwidth, rule.type.c_str()));
+                    if (dspv2) {
+                        // DSPv2 arm — ported from YosysHQ/yosys#4932
+                        // (povik/ql-dspv2 @ c68fd85b9ccceb773a4aaac2a35f7d90fbb15fc8).
+                        // Uses wider 32x18 and 16x9 multiplier shapes and the V2
+                        // pmgen pass (ql_dspv2). The ql_dsp_macc / ql_dsp_simd /
+                        // ql_dsp_io_regs helpers are re-used unchanged from V1
+                        // in this release; V2-specific helper-pass extensions
+                        // (the `-dspv2` flag on each) are deferred.
+                        //
+                        // Device-data convention (Aurora `device_data` submodule):
+                        // V1 and V2 devices ship their cell library under the
+                        // same filenames (`dsp_sim.v`, `dsp_map.v`,
+                        // `dsp_final_map.v`); the per-device file content selects
+                        // V1 vs V2 behaviour. We therefore reference the same
+                        // filenames on both arms here.
+                        run("ql_dsp_macc");
+                        run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
+                            "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
+                            "-D DSP_A_MAXWIDTH=32 -D DSP_B_MAXWIDTH=18 "
+                            "-D DSP_A_MINWIDTH=10 -D DSP_B_MINWIDTH=10 "
+                            "-D DSP_NAME=$__MUL32X18");
                         run("chtype -set $mul t:$__soft_mul");
+                        run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
+                            "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
+                            "-D DSP_A_MAXWIDTH=16 -D DSP_B_MAXWIDTH=9 "
+                            "-D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 "
+                            "-D DSP_NAME=$__MUL16X9");
+                        run("chtype -set $mul t:$__soft_mul");
+                        run("ql_dspv2");
+                        run("ql_dsp_simd");
+                        run("techmap -map " + lib_path + family + "/dsp_final_map.v");
+                        run("ql_dsp_io_regs");
+                    } else {
+                        run("ql_dsp_macc" + use_dsp_cfg_params);
+
+                        for (const auto &rule : dsp_rules) {
+                            run(stringf("techmap -map +/mul2dsp.v "
+                                        "-D DSP_A_MAXWIDTH=%zu -D DSP_B_MAXWIDTH=%zu "
+                                        "-D DSP_A_MINWIDTH=%zu -D DSP_B_MINWIDTH=%zu "
+                                        "-D DSP_NAME=%s",
+                                        rule.a_maxwidth, rule.b_maxwidth, rule.a_minwidth, rule.b_minwidth, rule.type.c_str()));
+                            run("chtype -set $mul t:$__soft_mul");
+                        }
+                        if (use_dsp_cfg_params.empty())
+                            run("techmap -map " + lib_path + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0");
+                        else
+                            run("techmap -map " + lib_path + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1");
+                        run("ql_dsp_simd");
+                        run("techmap -map " + lib_path + family + "/dsp_final_map.v");
+                        run("ql_dsp_io_regs");
                     }
-                    if (use_dsp_cfg_params.empty())
-                        run("techmap -map " + lib_path + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=0");
-                    else
-                        run("techmap -map " + lib_path + family + "/dsp_map.v -D USE_DSP_CFG_PARAMS=1");
-                    run("ql_dsp_simd");
-                    run("techmap -map " + lib_path + family + "/dsp_final_map.v");
-                    run("ql_dsp_io_regs");
                 }
             }
         }

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -606,6 +606,11 @@ struct SynthQuickLogicPass : public ScriptPass {
                         // run("ql_dsp_simd");
                         run("techmap -map " + lib_path + family + "/dsp_final_map.v");
                         // run("ql_dsp_io_regs");
+                        // Converts generic QL_DSPV2 cells emitted above into
+                        // mode-specific subtypes (QL_DSPV2_MULT/MULTACC/MULTADD
+                        // with REGIN/REGOUT variants). Only meaningful on the V2
+                        // path — V1 designs never produce QL_DSPV2 cells.
+                        run("ql_dspv2_types");
                     } else {
                         run("ql_dsp_macc" + use_dsp_cfg_params);
 
@@ -625,12 +630,6 @@ struct SynthQuickLogicPass : public ScriptPass {
                         run("techmap -map " + lib_path + family + "/dsp_final_map.v");
                         run("ql_dsp_io_regs");
                     }
-                    // Converts generic QL_DSPV2 cells (emitted by dsp_final_map.v on
-                    // V2 devices) into mode-specific subtypes (QL_DSPV2_MULT/
-                    // MULTACC/MULTADD with REGIN/REGOUT variants). No-op on V1
-                    // designs (no QL_DSPV2 cells present), so safe to run on both
-                    // arms.
-                    run("ql_dspv2_types");
                 }
             }
         }

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -540,7 +540,7 @@ struct SynthQuickLogicPass : public ScriptPass {
                         run("wreduce", "                         (for qlf_k6n10)");
                     }
                     run("select -clear", "                   (for qlf_k6n10)");
-                    run("ql_dsp", "                          (for qlf_k6n10)");
+                    run("ql_dspv1", "                        (for qlf_k6n10)");
                     run("chtype -set $mul t:$__soft_mul", "  (for qlf_k6n10)");
                 }
             }


### PR DESCRIPTION
Adds partial DSPv2 inference support to `synth_quicklogic` for the
`qlf_k6n10f` family, gated behind a new `-dspv2` flag. Scope for this
release is intentionally limited to basic MULT and MULTACC; cascade,
SIMD and IO-register packing are deferred.

## What's in

- New `-dspv2` flag on `synth_quicklogic`.
- DSPv1 path preserved bit-identical (namespace rename only:
  `ql_dsp` -> `ql_dspv1`, including the pmgen pattern file).
- New `ql_dspv2` pass imported byte-identical from
  YosysHQ/yosys#4932 (povik/ql-dspv2). The pass is built and
  registered but not invoked by the V2 arm in this release (see
  "Deferred" below).
- V2 arm in `synth_quicklogic.map_dsp` for `qlf_k6n10f`:
  - `ql_dsp_macc`
  - `techmap +/mul2dsp.v -map dsp_map.v` at 32x18 (DSP_SIGNEDONLY,
    min 10x10), `chtype`
  - `techmap +/mul2dsp.v -map dsp_map.v` at 16x9 (DSP_SIGNEDONLY,
    min 4x4), `chtype`
  - `techmap dsp_final_map.v`
- `QL_DSPV2.v` read gated on `synplify && !dspv2` (Synplify-only).

## Device-data convention

V1 and V2 devices ship their cell library under the same filenames
(`dsp_sim.v`, `dsp_map.v`, `dsp_final_map.v`). The per-device file
content selects V1 vs V2 behaviour; both arms therefore reference the
same filenames in `synth_quicklogic`.

## What's deferred (per PR #52 review)

- `ql_dspv2` cascade / register-packing pass invocation
- `ql_dsp_simd` SIMD packing
- `ql_dsp_io_regs` IO-register packing
- `-dspv2` flag extensions on `ql-dsp-macc.cc`, `ql-dsp-simd.cc`,
  `ql-dsp-io-regs.cc`
- DSPv2 inference test imports

The deferred passes are kept in the V2 arm as commented-out call
sites so the YosysHQ #4932 pipeline shape is preserved for clean
re-enable in a follow-up.

## Untouched

- `ql-qlf-plugin/qlf_k6n10f/` folder is byte-identical to
  `origin/main` (no Verilog library changes in this PR).
- DSPv1 behaviour is unchanged.

## Validation

- Plugin builds cleanly (macOS clang, yosys 0.55 headers).
- `git diff origin/main -- ql-qlf-plugin/qlf_k6n10f` is empty.