### PR TITLE
ql-dsp-macc: bypass DSPv2 MACC inference on dynamic feedback mux

### DIFF
--- a/ql-qlf-plugin/ql-dsp-macc.cc
+++ b/ql-qlf-plugin/ql-dsp-macc.cc
@@ -289,6 +289,24 @@ static void create_ql_macc_dsp_v2(ql_dsp_macc_pm &pm)
         return;
     }
 
+    // TEMPORARY: Reject MAC-with-clear/load patterns whose accumulator mux is
+    // driven by a dynamic select. Such a mux would force the DSPv2 'feedback_i'
+    // port to a runtime (non-constant) value, but the downstream
+    // ql_dspv2_types pass currently requires 'feedback' to be a constant config
+    // value (see get_const_port_value() in ql_dspv2_types.cc) and aborts
+    // synthesis otherwise. Until the type-mapping pass supports a dynamic
+    // feedback port, bypass DSP inference here and leave the pattern as soft
+    // logic.
+    if (st.mux != nullptr) {
+        RTLIL::SigSpec mux_sel = st.mux->getPort(ID(S));
+        SigMap sigmap(pm.module);
+        if (!sigmap(mux_sel).is_fully_const()) {
+            log_debug("Skipping DSPv2 MACC inference: feedback mux select is "
+                      "not constant, would require dynamic 'feedback' port.\n");
+            return;
+        }
+    }
+
     // Gather operand widths
     RTLIL::SigSpec sig_a = st.mul->getPort(ID(A));
     RTLIL::SigSpec sig_b = st.mul->getPort(ID(B));


### PR DESCRIPTION
## Summary

The DSPv2 type-mapping pass (`ql_dspv2_types`) requires the `feedback` port to be a
constant config value and aborts synthesis via `log_error()` when it is not
(`get_const_port_value()`). For MAC-with-clear/load patterns where the accumulator
mux select is a runtime signal, `create_ql_macc_dsp_v2()` wired `feedback_i` to that
dynamic signal, causing synthesis to fail with *"feedback is not constant"*.

## Fix

When the accumulator mux select is not fully constant, reject the match in
`create_ql_macc_dsp_v2()` and leave the pattern as soft logic so `feedback` stays a
constant. This is a temporary guard until `ql_dspv2_types` supports a dynamic
`feedback` port.

```cpp
if (st.mux != nullptr) {
    RTLIL::SigSpec mux_sel = st.mux->getPort(ID(S));
    SigMap sigmap(pm.module);
    if (!sigmap(mux_sel).is_fully_const()) {
        log_debug("Skipping DSPv2 MACC inference: feedback mux select is "
                  "not constant, would require dynamic 'feedback' port.\n");
        return;
    }
}
```

## Testing

Validated locally against aurora2's built-in yosys (rebuilt via
`make yosys-and-plugins USE_TABBYCAD=1`) on the `mac_32_preacc_clr` testcase
(QLF_K6N10 GF12 TURNKEY-FPGA3030):

- Synthesis now completes (`End of script`), no *"feedback is not constant"* error.
- The MAC maps to a plain `QL_DSPV2_MULT` plus soft logic for the dynamic
  clear/accumulate path, as intended.
- The remaining testcase failure is the unrelated, pre-existing foedag pin-table
  install bug (`Cannot find device pin table file!`) at P&R, not synthesis.