### PR TITLE
Fix: Resolve VCC/GND cell outputs when read as black boxes

### DIFF
--- a/ql-qlf-plugin/ql_dspv2_types.cc
+++ b/ql-qlf-plugin/ql_dspv2_types.cc
@@ -301,12 +301,11 @@ struct QlDSPV2TypesPass : public Pass {
 		}
 	}
 
-	void make_gnd_bits_unconn(RTLIL::Module *module,
-                          RTLIL::Cell *cell,
-                          const pool<RTLIL::IdString> &ports)
+	void make_gnd_bits_unconn(RTLIL::Cell *cell,
+							const pool<RTLIL::IdString> &ports,
+							SigMap &sigmap,
+							const dict<SigBit, State> &const_drivers)
 	{
-		SigMap sigmap(module);
-
 		log_debug("Processing cell %s (%s)\n",
 			log_id(cell->name), log_id(cell->type));
 
@@ -324,9 +323,19 @@ struct QlDSPV2TypesPass : public Pass {
 
 			for (int i = 0; i < sig.size(); i++)
 			{
-				RTLIL::SigBit bit = sig[i];
+				RTLIL::SigBit bit = sigmap(sig[i]);
 
-				if (sigmap(bit) == RTLIL::State::S0)
+				// Check internal S0 state
+				bool is_gnd = (bit == RTLIL::State::S0);
+
+				// Check black-box GND cell driver
+				if (!is_gnd) {
+					auto it = const_drivers.find(bit);
+					if (it != const_drivers.end() && it->second == State::S0)
+						is_gnd = true;
+				}
+
+				if (is_gnd)
 				{
 					log_debug("    bit %d -> GND replaced with \\unconn\n", i);
 					new_sig.append(SigSpec());
@@ -334,7 +343,7 @@ struct QlDSPV2TypesPass : public Pass {
 				}
 				else
 				{
-					new_sig.append(bit);
+					new_sig.append(sig[i]);
 				}
 			}
 
@@ -1239,11 +1248,12 @@ struct QlDSPV2TypesPass : public Pass {
 					case 0b01111110: //PREADDER_MULTADD
 					case 0b01110110: //PREADDER_MULTADD
 						make_gnd_bits_unconn(
-											module,
-											cell,
-											pool<RTLIL::IdString>{ 
-												ID(z_cin),
-											});
+						cell,
+						pool<RTLIL::IdString>{
+							ID(z_cin),
+						},
+						sigmap,
+						const_drivers);
 						transform_cell_with_ports(cell,
 												  RTLIL::escape_id("QL_DSPV2_PREADDER_MULTADD"),
 												  pool<RTLIL::IdString>{ 
@@ -1260,11 +1270,12 @@ struct QlDSPV2TypesPass : public Pass {
 					case 0b01111100: //MULTADD
 					case 0b01110100: //MULTADD
 						make_gnd_bits_unconn(
-											module,
-											cell,
-											pool<RTLIL::IdString>{ 
-												ID(z_cin),
-											});
+						cell,
+						pool<RTLIL::IdString>{
+							ID(z_cin),
+						},
+						sigmap,
+						const_drivers);
 						transform_cell_with_ports(cell,
 												  RTLIL::escape_id("QL_DSPV2_MULTADD"),
 												  pool<RTLIL::IdString>{ 
@@ -1280,11 +1291,12 @@ struct QlDSPV2TypesPass : public Pass {
 					case 0b01111101: //MULTADD_NEG
 					case 0b01110101: //MULTADD_NEG
 						make_gnd_bits_unconn(
-											module,
-											cell,
-											pool<RTLIL::IdString>{ 
-												ID(z_cin),
-											});
+						cell,
+						pool<RTLIL::IdString>{
+							ID(z_cin),
+						},
+						sigmap,
+						const_drivers);
 						transform_cell_with_ports(cell,
 												  RTLIL::escape_id("QL_DSPV2_MULTADD_NEG"),
 												  pool<RTLIL::IdString>{ 
@@ -1300,11 +1312,12 @@ struct QlDSPV2TypesPass : public Pass {
 					default:
 						log("Did not find any matching QL_DSPV2 models for %s\n", log_id(cell->name));
 						make_gnd_bits_unconn(
-											module,
-											cell,
-											pool<RTLIL::IdString>{ 
-												ID(z_cin),
-											});
+							cell,
+							pool<RTLIL::IdString>{
+								ID(z_cin),
+							},
+							sigmap,
+							const_drivers);
 						transform_cell_with_ports(cell,
 												  RTLIL::escape_id("QL_DSPV2"),
 												 pool<RTLIL::IdString>{ 

--- a/ql-qlf-plugin/ql_dspv2_types.cc
+++ b/ql-qlf-plugin/ql_dspv2_types.cc
@@ -51,18 +51,8 @@ struct QlDSPV2TypesPass : public Pass {
         return true;
     }
 
-	static int get_const_port_value(RTLIL::Module *module, RTLIL::Cell *cell, RTLIL::IdString port_name)
+	static void build_const_drivers(RTLIL::Module *module, SigMap &sigmap, dict<SigBit, State> &const_drivers)
 	{
-		if (!cell->hasPort(port_name))
-			log_error("Cell %s: port %s not found!\n",
-					log_id(cell), log_id(port_name));
-
-		SigMap sigmap(module);
-		RTLIL::SigSpec sig = sigmap(cell->getPort(port_name));
-
-		// SigMap resolves wire aliases but not VCC/GND cell outputs.
-		// Build a per-bit map for those drivers.
-		dict<SigBit, State> const_drivers;
 		for (auto *drv : module->cells()) {
 			if (drv->type == ID(VCC)) {
 				for (auto &bit : sigmap(drv->getPort(ID(P))))
@@ -72,6 +62,16 @@ struct QlDSPV2TypesPass : public Pass {
 					const_drivers[bit] = State::S0;
 			}
 		}
+	}
+
+	static int get_const_port_value(RTLIL::Cell *cell, RTLIL::IdString port_name,
+							SigMap &sigmap, const dict<SigBit, State> &const_drivers)
+	{
+		if (!cell->hasPort(port_name))
+			log_error("Cell %s: port %s not found!\n",
+					log_id(cell), log_id(port_name));
+
+		RTLIL::SigSpec sig = sigmap(cell->getPort(port_name));
 
 		for (auto &bit : sig) {
 			auto it = const_drivers.find(bit);
@@ -937,7 +937,9 @@ struct QlDSPV2TypesPass : public Pass {
 		log_header(design, "Executing QL_DSPV2_TYPES pass.\n");
 		
 		for (RTLIL::Module* module : design->selected_modules()){
-
+			SigMap sigmap(module);
+			dict<SigBit, State> const_drivers;
+			build_const_drivers(module, sigmap, const_drivers);
 			for (RTLIL::Cell* cell: module->selected_cells())
 			{
 				if (cell->type != ID(QL_DSPV2))
@@ -1021,9 +1023,9 @@ struct QlDSPV2TypesPass : public Pass {
 				if (FRAC_MODE)
 					log_debug("FRAC_MODE Enabled.\n");
 
-				int FEEDBACK = get_const_port_value(module, cell, ID(feedback));
+				int FEEDBACK = get_const_port_value(cell, ID(feedback), sigmap, const_drivers);
 				log_debug("FEEDBACK: %d.\n", FEEDBACK);
-				int OUTPUT_SELECT = get_const_port_value(module, cell, ID(output_select));
+				int OUTPUT_SELECT = get_const_port_value(cell, ID(output_select), sigmap, const_drivers);
 				log_debug("OUTPUT_SELECT: %d.\n", OUTPUT_SELECT);
 
 				replace_drop_net_with_keep_net(

--- a/ql-qlf-plugin/ql_dspv2_types.cc
+++ b/ql-qlf-plugin/ql_dspv2_types.cc
@@ -60,6 +60,25 @@ struct QlDSPV2TypesPass : public Pass {
 		SigMap sigmap(module);
 		RTLIL::SigSpec sig = sigmap(cell->getPort(port_name));
 
+		// SigMap resolves wire aliases but not VCC/GND cell outputs.
+		// Build a per-bit map for those drivers.
+		dict<SigBit, State> const_drivers;
+		for (auto *drv : module->cells()) {
+			if (drv->type == ID(VCC)) {
+				for (auto &bit : sigmap(drv->getPort(ID(P))))
+					const_drivers[bit] = State::S1;
+			} else if (drv->type == ID(GND)) {
+				for (auto &bit : sigmap(drv->getPort(ID(G))))
+					const_drivers[bit] = State::S0;
+			}
+		}
+
+		for (auto &bit : sig) {
+			auto it = const_drivers.find(bit);
+			if (it != const_drivers.end())
+				bit = SigBit(it->second);
+		}
+
 		log_debug("Cell %s %s = %s\n",
 			log_id(cell), log_id(port_name), log_signal(sig));
 

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -567,49 +567,51 @@ struct SynthQuickLogicPass : public ScriptPass {
                     run("wreduce t:$mul");
 
                     if (dspv2) {
-                        // DSPv2 arm — ported from YosysHQ/yosys#4932
-                        // (povik/ql-dspv2 @ c68fd85b9ccceb773a4aaac2a35f7d90fbb15fc8).
-                        // Uses wider 32x18 and 16x9 multiplier shapes via mul2dsp +
-                        // dsp_map.v techmap, followed by MULTACC inference via
-                        // ql_dsp_macc.
-                        //
-                        // Scope for this release (per PR #52 review): support is
-                        // limited to basic MULT (and MULTACC via ql_dsp_macc).
-                        // The cascade/register-packing pass (ql_dspv2), SIMD
-                        // packing (ql_dsp_simd) and IO-register packing
-                        // (ql_dsp_io_regs) are intentionally commented out and
-                        // deferred to a follow-up. Keeping them as commented
-                        // call sites preserves the #4932 pipeline shape for
-                        // easy re-enable.
-                        //
-                        // Device-data convention (Aurora `device_data` submodule):
-                        // V1 and V2 devices ship their cell library under the
-                        // same filenames (`dsp_sim.v`, `dsp_map.v`,
-                        // `dsp_final_map.v`); the per-device file content selects
-                        // V1 vs V2 behaviour. We therefore reference the same
-                        // filenames on both arms here.
-                        run("ql_dsp_macc -dspv2");
-                        run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
-                            "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
-                            "-D DSP_A_MAXWIDTH=32 -D DSP_B_MAXWIDTH=18 "
-                            "-D DSP_A_MINWIDTH=10 -D DSP_B_MINWIDTH=10 "
-                            "-D DSP_NAME=$__QL_MUL32X18");
-                        run("chtype -set $mul t:$__soft_mul");
-                        run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
-                            "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
-                            "-D DSP_A_MAXWIDTH=16 -D DSP_B_MAXWIDTH=9 "
-                            "-D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 "
-                            "-D DSP_NAME=$__QL_MUL16X9");
-                        run("chtype -set $mul t:$__soft_mul");
-                        // Deferred for this release — see comment above.
-                        // run("ql_dspv2");
-                        // run("ql_dsp_simd");
-                        run("techmap -map " + lib_path + family + "/dsp_final_map.v");
-                        // run("ql_dsp_io_regs");
-                        // Converts generic QL_DSPV2 cells emitted above into
-                        // mode-specific subtypes (QL_DSPV2_MULT/MULTACC/MULTADD
-                        // with REGIN/REGOUT variants). Only meaningful on the V2
-                        // path — V1 designs never produce QL_DSPV2 cells.
+                        if(!synplify) {
+                            // DSPv2 arm — ported from YosysHQ/yosys#4932
+                            // (povik/ql-dspv2 @ c68fd85b9ccceb773a4aaac2a35f7d90fbb15fc8).
+                            // Uses wider 32x18 and 16x9 multiplier shapes via mul2dsp +
+                            // dsp_map.v techmap, followed by MULTACC inference via
+                            // ql_dsp_macc.
+                            //
+                            // Scope for this release (per PR #52 review): support is
+                            // limited to basic MULT (and MULTACC via ql_dsp_macc).
+                            // The cascade/register-packing pass (ql_dspv2), SIMD
+                            // packing (ql_dsp_simd) and IO-register packing
+                            // (ql_dsp_io_regs) are intentionally commented out and
+                            // deferred to a follow-up. Keeping them as commented
+                            // call sites preserves the #4932 pipeline shape for
+                            // easy re-enable.
+                            //
+                            // Device-data convention (Aurora `device_data` submodule):
+                            // V1 and V2 devices ship their cell library under the
+                            // same filenames (`dsp_sim.v`, `dsp_map.v`,
+                            // `dsp_final_map.v`); the per-device file content selects
+                            // V1 vs V2 behaviour. We therefore reference the same
+                            // filenames on both arms here.
+                            run("ql_dsp_macc -dspv2");
+                            run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
+                                "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
+                                "-D DSP_A_MAXWIDTH=32 -D DSP_B_MAXWIDTH=18 "
+                                "-D DSP_A_MINWIDTH=10 -D DSP_B_MINWIDTH=10 "
+                                "-D DSP_NAME=$__QL_MUL32X18");
+                            run("chtype -set $mul t:$__soft_mul");
+                            run("techmap -map +/mul2dsp.v -map " + lib_path + family + "/dsp_map.v "
+                                "-D USE_DSP_CFG_PARAMS=0 -D DSP_SIGNEDONLY "
+                                "-D DSP_A_MAXWIDTH=16 -D DSP_B_MAXWIDTH=9 "
+                                "-D DSP_A_MINWIDTH=4 -D DSP_B_MINWIDTH=4 "
+                                "-D DSP_NAME=$__QL_MUL16X9");
+                            run("chtype -set $mul t:$__soft_mul");
+                            // Deferred for this release — see comment above.
+                            // run("ql_dspv2");
+                            // run("ql_dsp_simd");
+                            run("techmap -map " + lib_path + family + "/dsp_final_map.v");
+                            // run("ql_dsp_io_regs");
+                            // Converts generic QL_DSPV2 cells emitted above into
+                            // mode-specific subtypes (QL_DSPV2_MULT/MULTACC/MULTADD
+                            // with REGIN/REGOUT variants). Only meaningful on the V2
+                            // path — V1 designs never produce QL_DSPV2 cells.
+                        }
                         run("ql_dspv2_types");
                     } else {
                         run("ql_dsp_macc" + use_dsp_cfg_params);
@@ -810,6 +812,12 @@ struct SynthQuickLogicPass : public ScriptPass {
                                     run("design -save lut6");
                                     run("write_blif lut6.blif");
                                     run("design -load base");
+                                    if (synplify) {
+                                        std::string family_path = " " + lib_path + family;
+                                        run("flatten");
+                                        run("techmap -map" + family_path + "/synplify_map.v");
+                                        run("techmap");
+                                    }
                                     if(de == "delay")
                                         run("tee -o abc_de.log abc -script +/quicklogic/abc_scripts/dde.scr", "(for qlf_k6n10, qlf_k6n10f)");
                                     if(de == "area")

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -812,12 +812,6 @@ struct SynthQuickLogicPass : public ScriptPass {
                                     run("design -save lut6");
                                     run("write_blif lut6.blif");
                                     run("design -load base");
-                                    if (synplify) {
-                                        std::string family_path = " " + lib_path + family;
-                                        run("flatten");
-                                        run("techmap -map" + family_path + "/synplify_map.v");
-                                        run("techmap");
-                                    }
                                     if(de == "delay")
                                         run("tee -o abc_de.log abc -script +/quicklogic/abc_scripts/dde.scr", "(for qlf_k6n10, qlf_k6n10f)");
                                     if(de == "area")

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -810,6 +810,12 @@ struct SynthQuickLogicPass : public ScriptPass {
                                     run("design -save lut6");
                                     run("write_blif lut6.blif");
                                     run("design -load base");
+                                    if (synplify) {
+                                        std::string family_path = " " + lib_path + family;
+                                        run("flatten");
+                                        run("techmap -map" + family_path + "/synplify_map.v");
+                                        run("techmap");
+                                    }
                                     if(de == "delay")
                                         run("tee -o abc_de.log abc -script +/quicklogic/abc_scripts/dde.scr", "(for qlf_k6n10, qlf_k6n10f)");
                                     if(de == "area")

--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -810,12 +810,6 @@ struct SynthQuickLogicPass : public ScriptPass {
                                     run("design -save lut6");
                                     run("write_blif lut6.blif");
                                     run("design -load base");
-                                    if (synplify) {
-                                        std::string family_path = " " + lib_path + family;
-                                        run("flatten");
-                                        run("techmap -map" + family_path + "/synplify_map.v");
-                                        run("techmap");
-                                    }
                                     if(de == "delay")
                                         run("tee -o abc_de.log abc -script +/quicklogic/abc_scripts/dde.scr", "(for qlf_k6n10, qlf_k6n10f)");
                                     if(de == "area")


### PR DESCRIPTION
When running Synplify-DSPV2 flow, QL_DSPV2.v was read without the -lib, Yosys had full visibility into the VCC and GND module internals and would automatically constant-fold their outputs to the internal S1/S0 states. After adding the support for Yosys-DSPV2, we stopped reading this file for the Synplify flow. We are sourcing those definitions from synplify_map.v instead (read with -lib). Yosys treats VCC and GND as black boxes when being read as blockboxes. As a result, their output ports remain as unresolved wire bits rather than constants, causing the error:

ERROR: Cell u19.u14.u11.u8.Z_temp_11_2_0_23_0_.dsp: port feedback is not constant ({ \u19.u14.u11.u8.GND \u19.u14.u11.u8.GND \u19.u14.u11.u8.GND })

SigMap resolves wire aliases but does not follow through cell output ports. With -lib, Yosys pass cannot constant-fold VCC/GND outputs, so the bits driving the port were never reduced to S1/S0.

To fix the issue, after applying SigMap, we will explicitly iterate over the signal bits and check whether each is driven by a VCC or GND cell. Any such bit is substituted with the appropriate S1/S0 constant before the constness check runs, making the resolution independent of whether those modules were read with or without -lib.