### PR TITLE
Running LUT Deduplication at the End

### DIFF
--- a/ql-qlf-plugin/synth_quicklogic.cc
+++ b/ql-qlf-plugin/synth_quicklogic.cc
@@ -982,12 +982,12 @@ struct SynthQuickLogicPass : public ScriptPass {
                 if (synplify) {
 					run("opt -fast -mux_undef -undriven -fine" + noDFFArgs);
                     run("techmap -autoproc -map" + family_path + "/synplify_map.v");
-                    run("opt_lut_dedup");
                     run("opt_lut");
 					run("opt" + noDFFArgs);
                     run("opt_expr");
                     run("opt_merge");
                     run("opt_clean -purge");
+                    run("opt_lut_dedup");
                     run("stat");
                     run("clean");
                 }


### PR DESCRIPTION
This PR runs the LUT deduplication at the very end to make sure no LUTs are being missed after optimizations.