### PR TITLE
Exempt the fused Z=C addend from the DSP cascade fanout-1 check

### DIFF
--- a/ql-qlf-plugin/ql-dspv2-to-dspv4.cc
+++ b/ql-qlf-plugin/ql-dspv2-to-dspv4.cc
@@ -307,14 +307,22 @@ struct QlDspV2ToV4Pass : public Pass {
         return ports;
     }
 
-    // The QL_DSP4 input that carries the ALU addend and is realized on the tile's
-    // dedicated pcin_i cascade in the dsp4_logical arch: PCIN when OPMODE selects
-    // Z=PCIN (per-cell MULTADD), C when OPMODE selects Z=C (fused CONCAT+MULTADD --
-    // the fused addend also enters the ALU via pcin_i, confirmed in the packed
-    // .net). Any net on this port MUST be point-to-point (fanout 1): a physical DSP
-    // cascade wire cannot fork, and VPR aborts placement ("appears in 2 placement
-    // macros") if two chain heads share it. Returns an empty IdString for cells
-    // with no inter-cell cascade addend (Z=ACC feedback, or Z open).
+    // The QL_DSP4 input that carries the ALU addend over the tile's dedicated
+    // pcin_i cascade: PCIN, selected by OPMODE Z=001 (per-cell MULTADD). Any net on
+    // this port MUST be point-to-point (fanout 1) -- pcin_i has no general-routing
+    // connectivity (fc_val=0) and its only source is the dsp_p_chain <direct> from
+    // exactly one adjacent dsp.pcout_o, so VPR aborts placement ("appears in 2
+    // placement macros") if two chain heads share it.
+    //
+    // Z=011 (C, the fused CONCAT+MULTADD addend) is deliberately NOT a cascade
+    // port. C enters the tile on general routing -- dsp_wrapper.c_i is fed from the
+    // I* buses at fc_val=0.15 -- so a shared (or constant) C net is legal, needs no
+    // replication, and must not be rejected here. A fused pair collapses into a
+    // single QL_DSP4, so there is no inter-cell cascade left to constrain: A/B carry
+    // the operands and C carries the addend, all on general routing.
+    //
+    // Returns an empty IdString for cells with no dedicated cascade addend
+    // (Z=C, Z=ACC feedback, or Z open).
     static RTLIL::IdString cascade_addend_port(RTLIL::Cell *dsp)
     {
         if (dsp->type != ID(QL_DSP4) || !dsp->hasParam(ID(OPMODE)))
@@ -325,8 +333,6 @@ struct QlDspV2ToV4Pass : public Pass {
         int zsel = om.extract(4, 3).as_int(); // OPMODE[6:4]
         if (zsel == 1)                         // 001 = PCIN
             return ID(PCIN);
-        if (zsel == 3) // 011 = C (fused concat addend, routed via pcin_i)
-            return ID(C);
         return RTLIL::IdString();
     }
 
@@ -709,10 +715,13 @@ struct QlDspV2ToV4Pass : public Pass {
     // z_cin); a value shared across chains (e.g. a common a*b product Synplify
     // computes once and routes to several chains) is legal there because the
     // sharing is on GENERAL ROUTING, upstream of each chain's own private cascade
-    // injector. Our per-cell / fused mapping instead binds that shared feeder
-    // straight onto the ALU addend, which the dsp4_logical tile realizes on the
-    // dedicated pcin_i cascade -- turning a legal shared bus into an illegal
-    // fanout>1 cascade net that VPR cannot place ("appears in 2 placement macros").
+    // injector. Our per-cell mapping instead binds that shared feeder straight onto
+    // PCIN, which the dsp4_logical tile realizes on the dedicated pcin_i cascade --
+    // turning a legal shared bus into an illegal fanout>1 cascade net that VPR
+    // cannot place ("appears in 2 placement macros").
+    //
+    // Only the PCIN (Z=001) addend is affected; the fused Z=C addend rides general
+    // routing and is exempt (see cascade_addend_port).
     //
     // Restore Synplify's structure -- one private, single-fanout cascade head per
     // chain -- by replicating the feeder DSP once per extra consumer. The replica


### PR DESCRIPTION
## Problem

`ql_dspv2_to_dspv4` rejects valid Synplify netlists that contain two or more fused CONCAT_CASCADE + MULTADD pairs in the same module scope:

```
ERROR: ql_dspv2_to_dspv4: dedicated DSP cascade net \u_fft.u_fft_core.u_gadjconfigrounder.GND
feeds the cascade addend of both u_fft.u_fft_core.u_gadjconfigrounder.multiplier_mul_temp[1]_...dsp2_DSP4F
and u_fft.u_fft_core.u_gadjconfigrounder.multiplier_mul_temp[0]_...dsp2_DSP4F (fanout > 1).
A physical DSP cascade wire is point-to-point and cannot be placed; the shared feeder
could not be privately replicated (Bucket D invariant).
```

`cascade_addend_port()` treated both `PCIN` (OPMODE Z=001) and `C` (Z=011, the fused concat addend) as dedicated cascade ports and enforced fanout-1 on both. That is correct for `PCIN` and wrong for `C`.

## Root cause

The two ports reach the ALU by different physical routes:

| port | tile pin | connectivity | shared net legal? |
|---|---|---|---|
| `PCIN` | `pcin_i` | `fc_val=0`; only source is the `dsp_p_chain` `<direct>` from one adjacent `pcout_o` | no — point-to-point |
| `C` | `c_i` | fed from the `I*` general buses at `fc_val=0.15` | yes — ordinary routing |

Confirmed in `device_data/QLF_K6N10/INTEL/18AP/BOEING-2026Q4-240144`:

```xml
<fc_override port_name="pcin_i" fc_type="frac" fc_val="0"/>
<direct name="dsp_p_chain" from_pin="dsp.pcout_o[49:0]" to_pin="dsp.pcin_i[49:0]"
        x_offset="0" y_offset="-4" z_offset="0"/>

<direct input="dsp.I11[9:0]" output="dsp_wrapper.c_i[9:0]"/>
<direct input="dsp.I00[9:0]" output="dsp_wrapper.c_i[19:10]"/>
<direct input="dsp.I01[9:0]" output="dsp_wrapper.c_i[29:20]"/>
<direct input="dsp.I32[9:0]" output="dsp_wrapper.c_i[39:30]"/>
<direct input="dsp.I33[9:0]" output="dsp_wrapper.c_i[49:40]"/>
```

The same mapping holds in every arch carrying a `dsp4_logical` tile.

A fused pair collapses into a single `QL_DSP4` — A/B carry the operands, C carries the addend, all on general routing. There is no inter-cell cascade left to constrain, so the fanout-1 invariant does not apply.

## How the failing netlists hit it

DSP-V2 has no `C` port; the ALU's Z operand can only come from `z_cin`, the dedicated cascade. To add anything — including a compile-time constant — Synplify must source it from an upstream DSP's `z_cout`. For `mul_temp <= a*b + ROUND` it allocates a second DSP per multiply in CONCAT_CASCADE mode (`feedback=2`, `output_select=3`, no arithmetic) and ties its `a`/`b` to the module's `GND`/`VCC` primitives so that `z_cout = {a[31:0], b[17:0]}` equals the constant.

Synplify emits one `GND` cell per module scope, so two multiply-adds in the same module share it. After fusion (`C = {a1[31:0], b1[17:0]}`) 49 of the 50 `C` bits are that single net on both cells, and the check fires.

## Change

`ql-qlf-plugin/ql-dspv2-to-dspv4.cc`:

```diff
      int zsel = om.extract(4, 3).as_int(); // OPMODE[6:4]
      if (zsel == 1)                         // 001 = PCIN
          return ID(PCIN);
-     if (zsel == 3) // 011 = C (fused concat addend, routed via pcin_i)
-         return ID(C);
      return RTLIL::IdString();
```

Two functional lines. The rest of the diff updates the comments on `cascade_addend_port()` and `legalize_cascade_fanout()` to record the `pcin_i` vs `c_i` connectivity difference and why `C` is exempt.

`cascade_addend_port()` is called only from `legalize_cascade_fanout()` — the consumer-grouping loop and the assertion — so the blast radius is contained: the fanout-1 invariant now applies to `PCIN` alone, and the feeder-replication path for genuine shared DSP cascades is untouched.